### PR TITLE
Feature - "All Saves", "All Skills", "All [stat] Skills" as effect/proficiency options

### DIFF
--- a/rpg-docs/Model/Character/Characters.js
+++ b/rpg-docs/Model/Character/Characters.js
@@ -267,6 +267,21 @@ var attributeBase = preventLoop(function(charId, statName, groupNames){
 	return Math.floor(result);
 });
 
+var skillNames = function(skillName, charId){
+	var skill = Characters.calculate.getField(charId, skillName);
+	if (!skill) return [skillName];
+
+	var isSave = !!skillName.match(/Save$/);
+	if (isSave) {
+		var groupNames = ["allSaves"];
+	} else {
+		var groupNames = [skill.ability+"Skills", "allSkills"];
+	}
+
+	var result = [skillName].concat(groupNames);
+	return result;
+}
+
 if (Meteor.isClient) {
 	Template.registerHelper("characterCalculate", function(func, charId, input) {
 		try {
@@ -394,7 +409,7 @@ Characters.calculate = {
 	proficiency: memoize(function(charId, skillName){
 		//return largest value in proficiency array
 		var prof = Proficiencies.findOne(
-			{charId: charId, name: skillName, enabled: true},
+			{charId: charId, name: {$in: skillNames(skillName, charId)}, enabled: true},
 			{sort: {value: -1}}
 		);
 		return prof && prof.value || 0;

--- a/rpg-docs/client/views/character/effects/effectEdit/effectEdit.html
+++ b/rpg-docs/client/views/character/effects/effectEdit/effectEdit.html
@@ -13,7 +13,12 @@
 							 label="Value"
 							 floatinglabel
 							 value={{effectValue}}>
-					{{> formulaSuffix}}
+					{{#if showFormulaSuffix}}
+						{{> formulaSuffix}}
+					{{/if}}
+					{{#if showBracketSuffix}}
+						{{> bracketSuffix}}
+					{{/if}}
 				</paper-input>
 			{{else}}
 				<div style="height: 62px;"></div>

--- a/rpg-docs/client/views/character/effects/effectEdit/effectEdit.js
+++ b/rpg-docs/client/views/character/effects/effectEdit/effectEdit.js
@@ -161,6 +161,18 @@ Template.effectEdit.helpers({
 		) return false;
 		return true;
 	},
+	showFormulaSuffix: function(){
+		var op = this.operation;
+		if (
+			!op ||
+			op === "conditional"
+		) return false;
+		return true;
+	},
+	showBracketSuffix: function(){
+		if (this.operation === "conditional") return true;
+		return false;
+	},
 	effectValue: function(){
 		return this.calculation || this.value;
 	},

--- a/rpg-docs/client/views/character/effects/effectEdit/effectEdit.js
+++ b/rpg-docs/client/views/character/effects/effectEdit/effectEdit.js
@@ -7,12 +7,15 @@ var stats = [
 	{stat: "intelligence", name: "Intelligence", group: "Ability Scores"},
 	{stat: "wisdom", name: "Wisdom", group: "Ability Scores"},
 	{stat: "charisma", name: "Charisma", group: "Ability Scores"},
+
 	{name: "Strength Save", stat: "strengthSave", group: "Saving Throws"},
 	{name: "Dexterity Save", stat: "dexteritySave", group: "Saving Throws"},
 	{name: "Constitution Save", stat: "constitutionSave", group: "Saving Throws"},
 	{name: "Intelligence Save", stat: "intelligenceSave", group: "Saving Throws"},
 	{name: "Wisdom Save", stat: "wisdomSave", group: "Saving Throws"},
 	{name: "Charisma Save", stat: "charismaSave", group: "Saving Throws"},
+	{name: "All Saves", stat: "allSaves", group: "Saving Throws"},
+
 	{name: "Acrobatics", stat: "acrobatics", group: "Skills"},
 	{name: "Animal Handling", stat: "animalHandling", group: "Skills"},
 	{name: "Arcana", stat: "arcana", group: "Skills"},
@@ -32,6 +35,15 @@ var stats = [
 	{name: "Stealth", stat: "stealth", group: "Skills"},
 	{name: "Survival", stat: "survival", group: "Skills"},
 	{name: "Initiative", stat: "initiative", group: "Skills"},
+
+	{name: "All  Skills", stat: "allSkills", group: "Skill Groups"},
+	{name: "Strength Skills", stat: "strengthSkills", group: "Skill Groups"},
+	{name: "Dexterity Skills", stat: "dexteritySkills", group: "Skill Groups"},
+	{name: "Constitution Skills", stat: "constitutionSkills", group: "Skill Groups"},
+	{name: "Intelligence Skills", stat: "intelligenceSkills", group: "Skill Groups"},
+	{name: "Wisdom Skills", stat: "wisdomSkills", group: "Skill Groups"},
+	{name: "Charisma Skills", stat: "charismaSkills", group: "Skill Groups"},
+
 	{stat: "hitPoints", name: "Hit Points", group: "Stats"},
 	{stat: "armor", name: "Armor", group: "Stats"},
 	{stat: "dexterityArmor", name: "Dexterity Armor Bonus", group: "Stats"},
@@ -44,6 +56,7 @@ var stats = [
 	{stat: "expertiseDice", name: "Expertise Dice", group: "Stats"},
 	{stat: "superiorityDice", name: "Superiority Dice", group: "Stats"},
 	{stat: "carryMultiplier", name: "Carry Capacity Multiplier", group: "Stats"},
+
 	{stat: "level1SpellSlots", name: "level 1", group: "Spell Slots"},
 	{stat: "level2SpellSlots", name: "level 2", group: "Spell Slots"},
 	{stat: "level3SpellSlots", name: "level 3", group: "Spell Slots"},
@@ -53,10 +66,12 @@ var stats = [
 	{stat: "level7SpellSlots", name: "level 7", group: "Spell Slots"},
 	{stat: "level8SpellSlots", name: "level 8", group: "Spell Slots"},
 	{stat: "level9SpellSlots", name: "level 9", group: "Spell Slots"},
+
 	{stat: "d6HitDice", name: "d6 Hit Dice", group: "Hit Dice"},
 	{stat: "d8HitDice", name: "d8 Hit Dice", group: "Hit Dice"},
 	{stat: "d10HitDice", name: "d10 Hit Dice", group: "Hit Dice"},
 	{stat: "d12HitDice", name: "d12 Hit Dice", group: "Hit Dice"},
+
 	{stat: "acidMultiplier", name: "Acid", group: "Weakness/Resistance"},
 	{stat: "bludgeoningMultiplier", name: "Bludgeoning", group: "Weakness/Resistance"},
 	{stat: "coldMultiplier", name: "Cold", group: "Weakness/Resistance"},
@@ -121,7 +136,7 @@ Template.effectEdit.helpers({
 		var stat = statsDict[this.stat];
 		var group = stat && stat.group;
 		if (group === "Weakness/Resistance") return null;
-		if (group === "Saving Throws" || group === "Skills"){
+		if (group === "Saving Throws" || group === "Skills" || group === "Skill Groups"){
 			return skillOperations;
 		} else {
 			return attributeOperations;
@@ -159,7 +174,7 @@ var setStat = function(statName, effectId){
 	var setter = {stat: statName};
 	var effect = Effects.findOne(this._id);
 	var group = statsDict[statName].group;
-	if (group === "Saving Throws" || group === "Skills"){
+	if (group === "Saving Throws" || group === "Skills" || group === "Skill Groups"){
 		// Skills must have a valid skill operation
 		if (!_.contains(
 			_.map(skillOperations, ao => ao.operation),

--- a/rpg-docs/client/views/character/effects/effectView/effectView.js
+++ b/rpg-docs/client/views/character/effects/effectView/effectView.js
@@ -5,12 +5,15 @@ var stats = {
 	"intelligence":{"name":"Intelligence"},
 	"wisdom":{"name":"Wisdom"},
 	"charisma":{"name":"Charisma"},
+
 	"strengthSave":{"name":"Strength Save"},
 	"dexteritySave":{"name":"Dexterity Save"},
 	"constitutionSave":{"name":"Constitution Save"},
 	"intelligenceSave":{"name":"Intelligence Save"},
 	"wisdomSave":{"name":"Wisdom Save"},
 	"charismaSave":{"name":"Charisma Save"},
+	"allSaves": {"name":"All Saves"},
+
 	"acrobatics":{"name":"Acrobatics"},
 	"animalHandling":{"name":"Animal Handling"},
 	"arcana":{"name":"Arcana"},
@@ -30,6 +33,15 @@ var stats = {
 	"stealth":{"name":"Stealth"},
 	"survival":{"name":"Survival"},
 	"initiative":{"name":"Initiative"},
+
+	"allSkills": {"name":"All Skills"},
+	"strengthSkills": {"name":"All Strength Skills"},
+	"dexteritySkills": {"name":"All Dexterity Skills"},
+	"constitutionSkills": {"name":"All Constitution Skills"},
+	"intelligenceSkills": {"name":"All Intelligence Skills"},
+	"wisdomSkills": {"name":"All Wisdom Skills"},
+	"charismaSkills": {"name":"All Charisma Skills"},
+
 	"hitPoints":{"name":"Hit Points"},
 	"armor":{"name":"Armor"},
 	"dexterityArmor":{"name":"Dexterity Armor Bonus"},
@@ -42,6 +54,7 @@ var stats = {
 	"expertiseDice":{"name":"Expertise Dice"},
 	"superiorityDice":{"name":"Superiority Dice"},
 	"carryMultiplier": {"name": "Carry Capacity Multiplier"},
+
 	"level1SpellSlots":{"name":"level 1 Spell Slots"},
 	"level2SpellSlots":{"name":"level 2 Spell Slots"},
 	"level3SpellSlots":{"name":"level 3 Spell Slots"},
@@ -51,10 +64,12 @@ var stats = {
 	"level7SpellSlots":{"name":"level 7 Spell Slots"},
 	"level8SpellSlots":{"name":"level 8 Spell Slots"},
 	"level9SpellSlots":{"name":"level 9 Spell Slots"},
+
 	"d6HitDice":{"name":"d6 Hit Dice"},
 	"d8HitDice":{"name":"d8 Hit Dice"},
 	"d10HitDice":{"name":"d10 Hit Dice"},
 	"d12HitDice":{"name":"d12 Hit Dice"},
+
 	"acidMultiplier":{"name":"Acid damage", "group": "Weakness/Resistance"},
 	"bludgeoningMultiplier":{
 		"name":"Bludgeoning damage", "group": "Weakness/Resistance",

--- a/rpg-docs/client/views/character/effects/effectView/effectView.js
+++ b/rpg-docs/client/views/character/effects/effectView/effectView.js
@@ -173,7 +173,7 @@ Template.effectView.helpers({
 				return "Double Proficiency";
 		}
 		if (this.operation === "conditional"){
-			return this.calculation || this.value;
+			return evaluateString(this.charId, this.calculation || this.value);
 		}
 		if (stats[this.stat] && stats[this.stat].group === "Weakness/Resistance"){
 			if (this.value === 0.5) return "Resistance";

--- a/rpg-docs/client/views/character/proficiencies/proficiencyEdit/proficiencyEdit.js
+++ b/rpg-docs/client/views/character/proficiencies/proficiencyEdit/proficiencyEdit.js
@@ -14,6 +14,7 @@ var saves = [
 	{name: "Intelligence Save", stat: "intelligenceSave"},
 	{name: "Wisdom Save", stat: "wisdomSave"},
 	{name: "Charisma Save", stat: "charismaSave"},
+	{name: "All Saves", stat: "allSaves"},
 ];
 
 var skills = [
@@ -36,6 +37,14 @@ var skills = [
 	{name: "Stealth", stat: "stealth"},
 	{name: "Survival", stat: "survival"},
 	{name: "Initiative", stat: "initiative"},
+
+	{name:"All Skills", stat: "allSkills"},
+	{name:"All Strength Skills", stat: "strengthSkills"},
+	{name:"All Dexterity Skills", stat: "dexteritySkills"},
+	{name:"All Constitution Skills", stat: "constitutionSkills"},
+	{name:"All Intelligence Skills", stat: "intelligenceSkills"},
+	{name:"All Wisdom Skills", stat: "wisdomSkills"},
+	{name:"All Charisma Skills", stat: "charismaSkills"},
 ];
 
 Template.proficiencyEdit.helpers({

--- a/rpg-docs/client/views/character/proficiencies/proficiencyView/proficiencyView.js
+++ b/rpg-docs/client/views/character/proficiencies/proficiencyView/proficiencyView.js
@@ -5,6 +5,7 @@ var saves = {
 	intelligenceSave: "Intelligence Save",
 	wisdomSave: "Wisdom Save",
 	charismaSave: "Charisma Save",
+	allSaves: "All Saves",
 };
 
 var skills = {
@@ -27,6 +28,14 @@ var skills = {
 	stealth: "Stealth",
 	survival: "Survival",
 	initiative: "Initiative",
+
+	allSkills: "All Skills",
+	strengthSkills: "All Strength Skills",
+	dexteritySkills: "All Dexterity Skills",
+	constitutionSkills: "All Constitution Skills",
+	intelligenceSkills: "All Intelligence Skills",
+	wisdomSkills: "All Wisdom Skills",
+	charismaSkills: "All Charisma Skills",
 };
 
 Template.proficiencyView.helpers({

--- a/rpg-docs/client/views/character/stats/skillDialog/skillDialog.html
+++ b/rpg-docs/client/views/character/stats/skillDialog/skillDialog.html
@@ -108,7 +108,7 @@
 	{{#each conditionalEffects}}
 		<div class="spaceAfter">
 			<div class="paper-font-body2">{{sourceName}}</div>
-			<div>*{{statValue}}</div>
+			<div>*{{evaluateString charId statValue}}</div>
 		</div>
 	{{/each}}
 </template>

--- a/rpg-docs/client/views/character/stats/skillDialog/skillDialog.js
+++ b/rpg-docs/client/views/character/stats/skillDialog/skillDialog.js
@@ -121,9 +121,8 @@ const skillNames = function(skillName, charId){
 	}
 
 	var result = [skillName].concat(groupNames);
-	console.log(skillName, skill, result);
 	return result;
-}
+};
 
 Template.skillDialog.helpers({
 	color: function(){
@@ -146,7 +145,7 @@ Template.skillDialogView.helpers({
 	},
 	profSource: function(){
 		return Proficiencies.findOne(
-			{charId: this.charId, name: this.skillName},
+			{charId: this.charId, name: {$in: skillNames(this.skillName, this.charId)}},
 			{sort: {value: -1}}
 		);
 	},

--- a/rpg-docs/client/views/character/stats/skillDialog/skillDialog.js
+++ b/rpg-docs/client/views/character/stats/skillDialog/skillDialog.js
@@ -6,12 +6,15 @@ var stats = {
 	"intelligence":{"name":"Intelligence"},
 	"wisdom":{"name":"Wisdom"},
 	"charisma":{"name":"Charisma"},
+
 	"strengthSave":{"name":"Strength Save"},
 	"dexteritySave":{"name":"Dexterity Save"},
 	"constitutionSave":{"name":"Constitution Save"},
 	"intelligenceSave":{"name":"Intelligence Save"},
 	"wisdomSave":{"name":"Wisdom Save"},
 	"charismaSave":{"name":"Charisma Save"},
+	"allSaves": {"name":"All Saves"},
+
 	"acrobatics":{"name":"Acrobatics"},
 	"animalHandling":{"name":"Animal Handling"},
 	"arcana":{"name":"Arcana"},
@@ -31,6 +34,15 @@ var stats = {
 	"stealth":{"name":"Stealth"},
 	"survival":{"name":"Survival"},
 	"initiative":{"name":"Initiative"},
+
+	"allSkills": {"name":"All Skills"},
+	"strengthSkills": {"name":"All Strength Skills"},
+	"dexteritySkills": {"name":"All Dexterity Skills"},
+	"constitutionSkills": {"name":"All Constitution Skills"},
+	"intelligenceSkills": {"name":"All Intelligence Skills"},
+	"wisdomSkills": {"name":"All Wisdom Skills"},
+	"charismaSkills": {"name":"All Charisma Skills"},
+
 	"hitPoints":{"name":"Hit Points"},
 	"armor":{"name":"Armor"},
 	"dexterityArmor":{"name":"Dexterity Armor Bonus"},
@@ -42,6 +54,8 @@ var stats = {
 	"rageDamage":{"name":"Rage Damage"},
 	"expertiseDice":{"name":"Expertise Dice"},
 	"superiorityDice":{"name":"Superiority Dice"},
+	"carryMultiplier": {"name": "Carry Capacity Multiplier"},
+
 	"level1SpellSlots":{"name":"level 1 Spell Slots"},
 	"level2SpellSlots":{"name":"level 2 Spell Slots"},
 	"level3SpellSlots":{"name":"level 3 Spell Slots"},
@@ -51,10 +65,12 @@ var stats = {
 	"level7SpellSlots":{"name":"level 7 Spell Slots"},
 	"level8SpellSlots":{"name":"level 8 Spell Slots"},
 	"level9SpellSlots":{"name":"level 9 Spell Slots"},
+
 	"d6HitDice":{"name":"d6 Hit Dice"},
 	"d8HitDice":{"name":"d8 Hit Dice"},
 	"d10HitDice":{"name":"d10 Hit Dice"},
 	"d12HitDice":{"name":"d12 Hit Dice"},
+
 	"acidMultiplier":{"name":"Acid", "group": "Weakness/Resistance"},
 	"bludgeoningMultiplier":{"name":"Bludgeoning", "group": "Weakness/Resistance"},
 	"coldMultiplier":{"name":"Cold", "group": "Weakness/Resistance"},
@@ -92,6 +108,22 @@ var abilities = {
 	wisdom: {name: "Wisdom"},
 	charisma: {name: "Charisma"},
 };
+
+const skillNames = function(skillName, charId){
+	var skill = Characters.calculate.getField(charId, skillName);
+	if (!skill) return [skillName];
+
+	var isSave = !!skillName.match(/Save$/);
+	if (isSave) {
+		var groupNames = ["allSaves"];
+	} else {
+		var groupNames = [skill.ability+"Skills", "allSkills"];
+	}
+
+	var result = [skillName].concat(groupNames);
+	console.log(skillName, skill, result);
+	return result;
+}
 
 Template.skillDialog.helpers({
 	color: function(){
@@ -134,74 +166,83 @@ Template.skillDialogView.helpers({
 		return prof + "x Proficiency";
 	},
 	addEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "add",
 			enabled: true,
 		});
 	},
 	mulEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "mul",
 			enabled: true,
 		});
 	},
 	minEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "min",
 			enabled: true,
 		});
 	},
 	maxEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "max",
 			enabled: true,
 		});
 	},
 	advEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "advantage",
 			enabled: true,
 		});
 	},
 	dadvEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "disadvantage",
 			enabled: true,
 		});
 	},
 	conditionalEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "conditional",
 			enabled: true,
 		});
 	},
 	passiveEffects: function(){
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "passiveAdd",
 			enabled: true,
 		});
 	},
 	showPassiveTotal: function(){
 		if (this.skillName === "perception") return true;
+		var names=skillNames(this.skillName, this.charId);
 		return Effects.find({
 			charId: this.charId,
-			stat: this.skillName,
+			stat: {$in: names},
 			operation: "passiveAdd",
 			enabled: true,
 		}).count();

--- a/rpg-docs/client/views/character/stats/skillRow/skillRow.js
+++ b/rpg-docs/client/views/character/stats/skillRow/skillRow.js
@@ -1,3 +1,18 @@
+const skillNames = function(skillName, charId){
+	var skill = Characters.calculate.getField(charId, skillName);
+	if (!skill) return [skillName];
+
+	var isSave = !!skillName.match(/Save$/);
+	if (isSave) {
+		var groupNames = ["allSaves"];
+	} else {
+		var groupNames = [skill.ability+"Skills", "allSkills"];
+	}
+
+	var result = [skillName].concat(groupNames);
+	return result;
+};
+
 Template.skillRow.helpers({
 	skillMod: function() {
 		return signedString(
@@ -33,7 +48,7 @@ Template.skillRow.helpers({
 		var charId = Template.parentData()._id;
 		return Effects.find({
 			charId: charId,
-			stat: this.skill,
+			stat: {$in: skillNames(this.skill, charId)},
 			enabled: true,
 			operation: "conditional",
 		}).count();

--- a/rpg-docs/lib/functions/evaluate.js
+++ b/rpg-docs/lib/functions/evaluate.js
@@ -44,6 +44,7 @@ evaluate = function(charId, string, opts){
 		if (sub.toUpperCase()  === "LEVEL"){
 			return Characters.calculate.level(charId);
 		}
+		//spell list stuff
         if (spellListId && sub.toUpperCase() === "DC") {
             var list = SpellLists.findOne(spellListId);
             if (list && list.saveDC){


### PR DESCRIPTION
This branch allows you to select "All Saves", "All Skills", and "All [stat] Skills" (e.g. "All Dexterity Skills") as an option when selecting proficiencies or effect targets; these are correctly taken into account when computing the final value of skill or save modifiers.

It also allows conditional benefit effects to have {bracket formulae} which get evaluated.