### PR TITLE
Add Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:latest
+RUN apt-get update --quiet \
+    && apt-get install --quiet --yes \
+    bsdtar \
+    curl \
+    git
+RUN ln --symbolic --force $(which bsdtar) $(which tar)
+RUN useradd --create-home --shell /bin/bash dicecloud
+USER dicecloud
+WORKDIR /home/dicecloud
+RUN curl https://install.meteor.com/?release=1.8.0.2 | sh
+ENV PATH="${PATH}:/home/dicecloud/.meteor"
+COPY dev.sh ./dev.sh
+ENTRYPOINT ./dev.sh

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,4 @@
+set -o errexit -o nounset
+cd DiceCloud/app
+meteor npm install
+meteor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+services:
+  web:
+    build:
+      context: ./
+    volumes:
+      - .:/home/dicecloud/DiceCloud
+    ports:
+      - "3000:3000"
+      - "3003:3003"
+    # entrypoint: /bin/bash
+    # stdin_open: true
+    # tty: true


### PR DESCRIPTION
In order for a developer to run DiceCloud locally, all they need to do is run `docker-compose up --build`. This does take a very long time to execute but prevents a developer from needing to deal with configuration.