### PR TITLE
Order of ability scores in effects lists corrected

### DIFF
--- a/app/client/views/character/effects/effectsEditList/effectsEditList.js
+++ b/app/client/views/character/effects/effectsEditList/effectsEditList.js
@@ -9,7 +9,10 @@ Template.effectsEditList.helpers({
 			selector["parent.group"] = this.parentGroup;
 		}
 		var effects = Effects.find(selector).fetch();
-		return _.sortBy(effects, effect => statOrder[effect.stat] || 999);
+		return _.sortBy(effects, effect => {
+			if (!statOrder[effect.stat] && statOrder[effect.stat] !== 0) { return 999; }
+			return statOrder[effect.stat]
+		});
 	}
 });
 

--- a/app/client/views/character/effects/effectsViewList/effectsViewList.js
+++ b/app/client/views/character/effects/effectsViewList/effectsViewList.js
@@ -10,6 +10,9 @@ Template.effectsViewList.helpers({
 		let effects =  Effects.find(selector, {
 			fields: {parent: 0},
 		}).fetch();
-		return _.sortBy(effects, effect => statOrder[effect.stat] || 999);
+		return _.sortBy(effects, effect => {
+			if (!statOrder[effect.stat] && statOrder[effect.stat] !== 0) { return 999; }
+			return statOrder[effect.stat]
+		});
 	}
 });


### PR DESCRIPTION
Strength was always sorted as the last effect since it had an index of 0 and "0 || 999" = 999
Fixes #196 