### PR TITLE
Fix slot highlighting in the Cast Spell dialog

### DIFF
--- a/app/imports/ui/properties/components/attributes/SpellSlotListTile.vue
+++ b/app/imports/ui/properties/components/attributes/SpellSlotListTile.vue
@@ -13,10 +13,11 @@
           <div
             style="font-weight: 500; font-size: 24px"
             class="current-value"
+            :class="{ 'primary--text': highlight}"
           >
             {{ model.currentValue }}
           </div>
-          <div class="ml-2 max-value">
+          <div class="ml-2 max-value" :class="{ 'primary--text': highlight}">
             /{{ model.value }}
           </div>
         </div>
@@ -27,6 +28,7 @@
           <v-icon
             v-for="i in model.value"
             :key="i"
+            :class="{ 'primary--text': highlight}"
           >
             {{
               i > model.currentValue ?
@@ -36,7 +38,7 @@
           </v-icon>
         </div>
       </v-list-item-title>
-      <v-list-item-subtitle>
+      <v-list-item-subtitle :class="{ 'primary--text': highlight}">
         {{ model.name }}
       </v-list-item-subtitle>
     </v-list-item-content>
@@ -64,6 +66,10 @@ export default {
     },
     dark: Boolean,
     hideCastButton: Boolean,
+    highlight: {
+      type: Boolean,
+      default: function() { return false; }
+    }
 	},
 	computed: {
 		currentValue(){

--- a/app/imports/ui/properties/components/spells/CastSpellWithSlotDialog.vue
+++ b/app/imports/ui/properties/components/spells/CastSpellWithSlotDialog.vue
@@ -90,7 +90,7 @@
           v-for="spellSlot in spellSlots"
           :key="spellSlot._id"
           :model="spellSlot"
-          :class="{ 'primary--text': selectedSlotId === spellSlot._id }"
+          :highlight="selectedSlotId === spellSlot._id"
           hide-cast-button
           @click="selectedSlotId = spellSlot._id"
         />


### PR DESCRIPTION
The primary--text color was overridden by a more precise rule. Attributing the class directly to the elements that should be highlighted fixes the problem.