### PR TITLE
Cast unprepared ritual spells

### DIFF
--- a/app/imports/api/creature/denormalise/recomputeInactiveProperties.js
+++ b/app/imports/api/creature/denormalise/recomputeInactiveProperties.js
@@ -7,7 +7,7 @@ export default function recomputeInactiveProperties(ancestorId){
       {disabled: true}, // Everything can be disabled
       {type: 'buff', applied: false}, // Buffs can be applied
       {type: 'item', equipped: {$ne: true}},
-      {type: 'spell', prepared: {$ne: true}, alwaysPrepared: {$ne: true}},
+      {type: 'spell', prepared: {$ne: true}, alwaysPrepared: {$ne: true}, ritual: {$ne: true}},
     ],
   };
   let disabledIds = CreatureProperties.find(disabledFilter, {

--- a/app/imports/ui/creature/character/characterSheetTabs/StatsTab.vue
+++ b/app/imports/ui/creature/character/characterSheetTabs/StatsTab.vue
@@ -478,9 +478,9 @@
             creatureId: this.creatureId,
             slotId,
           },
-          callback({spellId, slotId} = {}){
+          callback({spellId, slotId, castRitual} = {}){
             if (!spellId) return;
-            castSpellWithSlot.call({spellId, slotId}, error => {
+            castSpellWithSlot.call({spellId:spellId, slotId:slotId, castRitual:castRitual}, error => {
               if (error) console.error(error);
             });
           },


### PR DESCRIPTION
This PR adds a checkbox in the spell cast dialog indicating whether the user wants to cast a ritual or not.
It then bypasses most slots computation.

As a side effect, it also lets unprepared-but-ritual spells stay in the spell list (in the spells page).

![Screenshot_20210810_221957](https://user-images.githubusercontent.com/498483/128929461-b7dbb40d-1f8b-42fc-9eb8-a9c7e641a51f.png)

This was made for my local instance, so it may be a bit rough on the edges.
Notably:
- I haven't included a checkbox (or a property? should it be dynamic?) inside the spell list to indicate whether the class is allowed to cast as ritual or not, so anyone with a least a spell slot can.
- It doesn't indicate in the log that the spell was cast as a ritual.

This wasn't concerted with @ThaumRystra beforehand, so it would completely understand if you don't think it's the right solution for the problem. Still, I needed it locally, so here it is :-)
Let me know if I should modify something.