### PR TITLE
Add access control headers to character JSON API route.

### DIFF
--- a/app/Routes/API.js
+++ b/app/Routes/API.js
@@ -29,6 +29,11 @@ Router.map(function () {
         where: "server",
         action: function () {
             this.response.setHeader("Content-Type", "application/json");
+            if (this.request.headers.origin !== undefined) {
+                this.response.setHeader("Access-Control-Allow-Origin", this.request.headers.origin);
+            }
+            this.response.setHeader("Access-Control-Allow-Methods", "GET,OPTIONS");
+            this.response.setHeader("Access-Control-Allow-Headers", "Access-Control-Allow-Headers, Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers");
             var query = this.params.query;
             var key = query && query.key;
             ifKeyValid(key, this.response, "jsonCharacterSheet", () => {


### PR DESCRIPTION
With the access control headers included in the response, character JSON models can be read using cross-domain requests.