### PR TITLE
Refactor sendWebhook to not rely on Discord.js

### DIFF
--- a/app/imports/server/discord/sendWebhook.js
+++ b/app/imports/server/discord/sendWebhook.js
@@ -1,16 +1,16 @@
-import Discord from 'discord.js'
+import request from 'request'
+
 export default function sendWebhook({webhookURL, data = {}}){
-  //webhookURL = https://discordapp.com/api/webhooks/<id>/<token>
-  let urlArray = webhookURL.split('/');
-  let token = urlArray.pop();
-  let id = urlArray.pop();
-
-  // prevent discord mention exploit
-  data.disableMentions = 'all';
-
-  const hook = new Discord.WebhookClient(id, token);
-  // Send a message using the webhook
-  hook.send(data);
+  request({
+    url: webhookURL,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    json: true,
+    body: {
+      ...data,
+      allowed_mentions: {parse:[]} // prevent discord mention exploit
+    }
+  })
 }
 
 export function sendWebhookAsCreature({creature, data = {}}){

--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,6 @@
     "css-box-shadow": "^1.0.0-3",
     "date-fns": "^1.30.1",
     "ddp-rate-limiter-mixin": "^1.1.10",
-    "discord.js": "^12.5.3",
     "dompurify": "^2.3.8",
     "ignore": "^5.2.0",
     "ignore-styles": "^5.0.1",


### PR DESCRIPTION
This allows Discord.js to be dropped as a dependency (as that's the only area it was used), and will also enable webhooks to send to other sites than Discord as an added bonus (albeit still in Discord's format; handling that data appropriately will need to be a given site's responsibility). Otherwise, it should function identically to the existing code.

There should probably also be consideration given to switching the `request` library for something like `node-fetch`, as `request` has been deprecated for about 3.5 years, but that's a project for another day.