### PR TITLE
Fix Action scope variables

### DIFF
--- a/app/imports/api/engine/actions/applyPropertyByType/applyAction.js
+++ b/app/imports/api/engine/actions/applyPropertyByType/applyAction.js
@@ -163,8 +163,9 @@ function rollAttack(attack, scope) {
     value = rollDice(1, 20)[0];
     resultPrefix = `1d20 [${value}] ${rollModifierText}`
   }
-  scope['$attackRoll'] = { value };
+  scope['$attackDiceRoll'] = { value };
   const result = value + attack.value;
+  scope['$attackRoll'] = { result };
   const { criticalHit, criticalMiss } = applyCrits(value, scope);
   return { resultPrefix, result, value, criticalHit, criticalMiss };
 }


### PR DESCRIPTION
As per the docs, $attackDiceRoll should be the value of the d20 before modifiers, and $attackRoll should the the total value, after modifiers. Pre-patch, the former variable is never defined, and the latter variable has the wrong value.