### PR TITLE
Update Github link in sidebar

### DIFF
--- a/app/imports/client/ui/layouts/Sidebar.vue
+++ b/app/imports/client/ui/layouts/Sidebar.vue
@@ -103,7 +103,7 @@ export default {
         { title: 'About', icon: 'mdi-sign-text', to: '/about' },
         { title: 'Documentation', icon: 'mdi-book-open-variant', to: '/docs' },
         { title: 'Patreon', icon: 'mdi-patreon', href: 'https://www.patreon.com/dicecloud' },
-        { title: 'Github', icon: 'mdi-github', href: 'https://github.com/ThaumRystra/DiceCloud/tree/version-2' },
+        { title: 'Github', icon: 'mdi-github', href: 'https://github.com/ThaumRystra/DiceCloud' },
       ];
       return links.filter(link => !link.requireLogin || isLoggedIn);
     },


### PR DESCRIPTION
Looks like the `version-2` branch got merged and deleted, invalidating this link in the sidebar.