### PR TITLE
Fix link to dicecloud.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 DiceCloud
 ========
 
-This is the repo for [DiceCloud](dicecloud.com).
+This is the repo for [DiceCloud](https://dicecloud.com).
 
 DiceCloud is a free, auditable, real-time character sheet for D&D 5e.
 


### PR DESCRIPTION
The link wasn't working, because the protocol wasn't in the link, therefore Github's Markdown processor was treating it as a relative link.