### PR TITLE
Fix health bar filtering in dealDamage function

### DIFF
--- a/app/imports/api/engine/actions/applyPropertyByType/applyDamage.js
+++ b/app/imports/api/engine/actions/applyPropertyByType/applyDamage.js
@@ -194,14 +194,18 @@ function dealDamage({ target, damageType, amount, actionContext }) {
   let healthBars = getPropertiesOfType(target._id, 'attribute');
 
   // Keep only the healthbars that can take damage/healing
-  remove(healthBars, (bar) =>
-    bar.attributeType !== 'healthBar' ||
-    bar.inactive ||
-    bar.removed ||
-    bar.overridden ||
-    (amount >= 0 && bar.healthBarNoDamage) ||
-    (amount < 0 && bar.healthBarNoHealing)
-  );
+  healthBars = healthBars.filter((bar) => {
+    if (bar.attributeType !== 'healthBar' || bar.inactive || bar.removed || bar.overridden) {
+      return false;
+    }
+    if (damageType === 'healing' && bar.healthBarNoHealing) {
+      return false;
+    }
+    if (damageType !== 'healing' && amount >= 0 && bar.healthBarNoDamage) {
+      return false;
+    }
+    return true;
+  });
 
   // Sort healthbars by damage/healing order or tree order as a fallback
   healthBars.sort((a, b) => {


### PR DESCRIPTION
This pull request addresses an issue with the dealDamage function where health bars with the healthBarNoHealing flag set to True were still being healed. The problem was related to the logic used to filter out health bars that should not be affected by the current damage type.

Changes:

- Replaced the remove function with the native JavaScript filter function.
- Updated the filter condition to correctly filter health bars based on the damage type (healing or damage).