### PR TITLE
Fix triggerMatchTags function to correctly handle 'NOT' operation

### DIFF
--- a/app/imports/api/engine/actions/applyTriggers.js
+++ b/app/imports/api/engine/actions/applyTriggers.js
@@ -89,23 +89,26 @@ function triggerMatchTags(trigger, prop) {
     matched = true;
   }
   // Check the extra tags
-  trigger.extraTags?.forEach(extra => {
-    if (extra.operation === 'OR') {
-      if (matched) return;
-      if (
-        !extra.tags.length ||
-        difference(extra.tags, propTags).length === 0
-      ) {
-        matched = true;
-      }
-    } else if (extra.operation === 'NOT') {
-      if (
-        extra.tags.length &&
-        intersection(extra.tags, propTags)
-      ) {
-        return false;
+  if (trigger.extraTags) {
+    for (const extra of trigger.extraTags) {
+      if (extra.operation === 'OR') {
+        if (matched) break;
+        if (
+          !extra.tags.length ||
+          difference(extra.tags, propTags).length === 0
+        ) {
+          matched = true;
+        }
+      } else if (extra.operation === 'NOT') {
+        if (
+          extra.tags.length &&
+          intersection(extra.tags, propTags).length > 0
+        ) {
+          matched = false;
+          break;
+        }
       }
     }
-  });
+  }
   return matched;
 }


### PR DESCRIPTION
This pull request addresses an issue in the triggerMatchTags function where it returned an incorrect result when the targetTags property was empty and the 'NOT' operation was evaluated in the extraTags. The function would return true instead of false when it should have.

Changes:

- Replaced the forEach loop with a for...of loop to iterate through trigger.extraTags to properly set the matched variable and break the loop when necessary.
- Updated the condition for the 'NOT' operation to set matched to false and break the loop when the condition is met.