### PR TITLE
Add an option for flat reductions to damage multipliers

### DIFF
--- a/app/imports/api/engine/actions/applyPropertyByType/applyDamage.js
+++ b/app/imports/api/engine/actions/applyPropertyByType/applyDamage.js
@@ -163,6 +163,14 @@ function applyDamageMultipliers({ target, damage, damageProp, logValue }) {
       logValue.push(`Vulnerable to ${damageTypeText}`);
       damage = Math.floor(damage * 2);
     }
+    if (
+      multiplier.reduction &&
+      some(multiplier.reductions, multiplierAppliesTo(damageProp, 'reduction'))
+    ) {
+      let reductionAmount = multiplier.reductions.reduce((a,b) => a + b.reductionAmount.value, 0);
+      logValue.push(`${damageType[0].toUpperCase()}${damageTypeText.slice(1)} reduced by ${reductionAmount}`);
+      damage = Math.max(damage - reductionAmount, 0);
+    }
   }
   return damage;
 }

--- a/app/imports/api/engine/computation/computeComputation/computeByType/computeVariable.js
+++ b/app/imports/api/engine/computation/computeComputation/computeByType/computeVariable.js
@@ -69,6 +69,10 @@ function computeVariableProp(computation, node, prop) {
     prop.vulnerability = node.data.vulnerability;
     prop.vulnerabilities = node.data.vulnerabilities;
   }
+  if (node.data.reduction) {
+    prop.reduction = node.data.reduction;
+    prop.reductions = node.data.reductions;
+  }
 
   if (prop.type === 'attribute') {
     computeVariableAsAttribute(computation, node, prop);
@@ -100,5 +104,9 @@ function combineMultiplierAggregator(node) {
   if (aggregator.vulnerabilities?.length) {
     node.data.vulnerability = true;
     node.data.vulnerabilities = aggregator.vulnerabilities;
+  }
+  if (aggregator.reductions?.length) {
+    node.data.reduction = true;
+    node.data.reductions = aggregator.reductions;
   }
 }

--- a/app/imports/api/engine/computation/computeComputation/computeByType/computeVariable/aggregate/aggregateDamageMultiplier.js
+++ b/app/imports/api/engine/computation/computeComputation/computeByType/computeVariable/aggregate/aggregateDamageMultiplier.js
@@ -11,6 +11,7 @@ export default function aggregateDamageMultipliers({node, linkedNode, link}){
     immunities: [],
     resistances: [],
     vulnerabilities: [],
+    reductions: [],
   }
   // Store a short reference to the aggregator
   const aggregator = node.data.multiplierAggregator;
@@ -23,6 +24,9 @@ export default function aggregateDamageMultipliers({node, linkedNode, link}){
   if (linkedNode.data.includeTags?.length){
     keysToStore.push('includeTags');
   }
+  if (linkedNode.data.value === -1){
+    keysToStore.push('reductionAmount');
+  }
   const storedMultiplier = pick(linkedNode.data, keysToStore);
 
   // Store the multiplier in the appropriate field
@@ -32,5 +36,7 @@ export default function aggregateDamageMultipliers({node, linkedNode, link}){
     aggregator.resistances.push(storedMultiplier);
   } else if (multiplierValue === 2){
     aggregator.vulnerabilities.push(storedMultiplier);
+  } else if (multiplierValue === -1){
+    aggregator.reductions.push(storedMultiplier);
   }
 }

--- a/app/imports/api/engine/computation/computeComputation/computeByType/computeVariable/computeImplicitVariable.js
+++ b/app/imports/api/engine/computation/computeComputation/computeByType/computeVariable/computeImplicitVariable.js
@@ -20,6 +20,10 @@ import getAggregatorResult from './getAggregatorResult.js';
     prop.vulnerability = node.data.vulnerability;
     prop.vulnerabilities = node.data.vulnerabilities;
   }
+  if (node.data.reduction){
+    prop.reduction = node.data.reduction;
+    prop.reductions = node.data.reductions;
+  }
 
    const result = getAggregatorResult(node);
    if (result !== undefined){

--- a/app/imports/api/properties/DamageMultipliers.js
+++ b/app/imports/api/properties/DamageMultipliers.js
@@ -1,3 +1,4 @@
+import createPropertySchema from './subSchemas/createPropertySchema';
 import SimpleSchema from 'simpl-schema';
 import STORAGE_LIMITS from '/imports/constants/STORAGE_LIMITS.js';
 import VARIABLE_NAME_REGEX from '/imports/constants/VARIABLE_NAME_REGEX.js';
@@ -6,7 +7,7 @@ import VARIABLE_NAME_REGEX from '/imports/constants/VARIABLE_NAME_REGEX.js';
  * DamageMultipliers are multipliers that affect how much damage is taken from
  * a given damage type
  */
-let DamageMultiplierSchema = new SimpleSchema({
+let DamageMultiplierSchema = createPropertySchema({
   name: {
     type: String,
     optional: true,
@@ -27,7 +28,12 @@ let DamageMultiplierSchema = new SimpleSchema({
   value: {
     type: Number,
     defaultValue: 0.5,
-    allowedValues: [0, 0.5, 2],
+    allowedValues: [0, 0.5, 2, -1],
+  },
+  // The amount to apply for flat reductions
+  reductionAmount: {
+    type: 'fieldToCompute',
+    optional: true
   },
   // Tags which bypass this multiplier (OR)
   excludeTags: {
@@ -51,6 +57,15 @@ let DamageMultiplierSchema = new SimpleSchema({
   },
 });
 
-const ComputedOnlyDamageMultiplierSchema = new SimpleSchema({});
+const ComputedOnlyDamageMultiplierSchema = createPropertySchema({
+  reductionAmount: {
+    type: 'computedOnlyField',
+    optional: true,
+  },
+});
 
-export { DamageMultiplierSchema, ComputedOnlyDamageMultiplierSchema };
+const ComputedDamageMultiplierSchema = new SimpleSchema()
+  .extend(ComputedOnlyDamageMultiplierSchema)
+  .extend(DamageMultiplierSchema);
+
+export { DamageMultiplierSchema, ComputedDamageMultiplierSchema, ComputedOnlyDamageMultiplierSchema };

--- a/app/imports/api/properties/computedPropertySchemasIndex.js
+++ b/app/imports/api/properties/computedPropertySchemasIndex.js
@@ -10,7 +10,7 @@ import { ComputedClassLevelSchema } from '/imports/api/properties/ClassLevels.js
 import { ConstantSchema } from '/imports/api/properties/Constants.js';
 import { ComputedContainerSchema } from '/imports/api/properties/Containers.js';
 import { ComputedDamageSchema } from '/imports/api/properties/Damages.js';
-import { DamageMultiplierSchema } from '/imports/api/properties/DamageMultipliers.js';
+import { ComputedDamageMultiplierSchema } from '/imports/api/properties/DamageMultipliers.js';
 import { ComputedEffectSchema } from '/imports/api/properties/Effects.js';
 import { ComputedFeatureSchema } from '/imports/api/properties/Features.js';
 import { ComputedFolderSchema } from '/imports/api/properties/Folders.js';
@@ -39,7 +39,7 @@ const propertySchemasIndex = {
   classLevel: ComputedClassLevelSchema,
   constant: ConstantSchema,
   damage: ComputedDamageSchema,
-  damageMultiplier: DamageMultiplierSchema,
+  damageMultiplier: ComputedDamageMultiplierSchema,
   effect: ComputedEffectSchema,
   feature: ComputedFeatureSchema,
   folder: ComputedFolderSchema,

--- a/app/imports/client/ui/properties/components/damageMultipliers/DamageMultiplierCard.vue
+++ b/app/imports/client/ui/properties/components/damageMultipliers/DamageMultiplierCard.vue
@@ -13,7 +13,10 @@
               {{ title(multiplier) }}
             </v-list-item-title>
             <v-list-item-subtitle v-if="multiplier.name">
-              {{ multiplier.name }}
+              {{ multiplier.name }} 
+              <span v-if="multiplier.value === -1 && multiplier.reductionAmount">
+                (reduction by {{ multiplier.reductionAmount.value }})
+              </span>
             </v-list-item-subtitle>
             <v-list-item-subtitle class="d-flex flex-wrap align-center">
               <v-chip
@@ -88,6 +91,7 @@ export default {
         case 0: return 'Immunity';
         case 0.5: return 'Resistance';
         case 2: return 'Vulnerability';
+        case -1: return 'Reduction';
       }
     }
   }

--- a/app/imports/client/ui/properties/forms/DamageMultiplierForm.vue
+++ b/app/imports/client/ui/properties/forms/DamageMultiplierForm.vue
@@ -16,6 +16,9 @@
           }, {
             value: 0,
             name: 'Immunity',
+          }, {
+            value: -1,
+            name: 'Reduction',
           }]"
           :error-messages="errors.value"
           @change="change('value', ...arguments)"
@@ -23,6 +26,21 @@
       </v-col>
     </v-row>
     <v-row dense>
+      <v-expand-transition>
+        <v-col
+          v-if="model.value === -1"
+          cols="12"
+        >
+          <computed-field
+            label="Reduction Amount"
+            hint="The amount by which to reduce the incoming damage"
+            :model="model.reductionAmount"
+            :error-messages="errors.reductionAmount"
+            @change="({path, value, ack}) =>
+              $emit('change', {path: ['reductionAmount', ...path], value, ack})"
+          />
+        </v-col>
+      </v-expand-transition>
       <v-col cols="12">
         <smart-combobox
           label="Damage Types"

--- a/app/imports/client/ui/properties/viewers/DamageMultiplierViewer.vue
+++ b/app/imports/client/ui/properties/viewers/DamageMultiplierViewer.vue
@@ -6,6 +6,11 @@
         :value="operation"
       />
       <property-field
+        v-if="model.value === -1 && model.reductionAmount"
+        name="Reduction Amount"
+        :value="model.reductionAmount.value"
+      />
+      <property-field
         name="Damage types"
         wrap
       >
@@ -67,6 +72,7 @@ export default {
         case 0: return 'Immunity';
         case 0.5: return 'Resistance';
         case 2: return 'Vulnerability';
+        case -1: return 'Reduction';
         default: return '';
       }
     },


### PR DESCRIPTION
As discussed on Discord, see [feature request](https://discord.com/channels/120762305087668224/1137538368662687806).

Adds a Reduction type to Damage Multipliers, which reveals a new Reduction Amount field when selected. When damage is applied, relevant reduction amounts are subtracted from the damage **after** multipliers, and cannot reduce damage below 0.

Potential good features to add before merging:
- Before/after multipliers option (5e RAW is always after iirc but homebrew/DMs may differ)
- Adjustable minimum value after reduction (somewhat tricky since different reductions may have different minimums)

Potential gotcha: the `value` of a multiplier in Reduction mode is `-1`, which may cause issues with calculations that naively assume the value can be multiplied in directly. It may be best to adjust this before merging, but I'm not sure what the best alternative would be.