### PR TITLE
Fix Reference missing from type search in library tree

### DIFF
--- a/app/imports/client/ui/components/tree/TreeSearchInput.vue
+++ b/app/imports/client/ui/components/tree/TreeSearchInput.vue
@@ -108,7 +108,6 @@ import escapeRegex from '/imports/api/utility/escapeRegex.js';
 
 const filterOptions = [];
 for (let key in PROPERTIES) {
-  if (key === 'reference') continue;
   filterOptions.push({
     text: PROPERTIES[key].name,
     value: key,
@@ -121,11 +120,14 @@ export default {
       type: Object,
       default: undefined,
     },
+    isLibrary: {
+      type: Boolean,
+      default: false
+    }
   },
   data(){return {
     typeFilterInput: [],
     fieldFilters: [{field: 'name', value: undefined}],
-    filterOptions,
     menu: false,
   }},
   computed: {
@@ -155,6 +157,11 @@ export default {
         }
       });
       return filter;
+    },
+    filterOptions() {
+      return !this.isLibrary 
+        ? filterOptions.filter(p => p.value !== 'reference')
+        : filterOptions;
     },
     extraFields() {
       let extraFields = [];

--- a/app/imports/client/ui/library/LibraryAndNode.vue
+++ b/app/imports/client/ui/library/LibraryAndNode.vue
@@ -29,6 +29,7 @@
           v-model="filter"
           class="mx-4"
           @extra-fields-changed="val => extraFields = val"
+          :is-library="true"
         />
         <v-spacer />
         <v-fade-transition>


### PR DESCRIPTION
As discussed in Discord, see [feature request](https://discord.com/channels/120762305087668224/1125600565108408320).

Rather than remove Reference from the list of searchable types no matter what, Reference is only removed from the list when the tree search component is not marked as being in a library view.