### PR TITLE
Make references add their own tags to the referenced property on insert

### DIFF
--- a/app/imports/api/creature/creatureProperties/methods/insertPropertyFromLibraryNode.js
+++ b/app/imports/api/creature/creatureProperties/methods/insertPropertyFromLibraryNode.js
@@ -178,6 +178,7 @@ function reifyNodeReferences(nodes, visitedRefs = new Set(), depth = 0) {
     try {
       referencedNode = fetchDocByRef(node.ref);
       referencedNode.order = node.order;
+      referencedNode.tags = [...new Set(referencedNode.tags.concat(node.tags ?? []))];
       // We are definitely replacing this node, so add it to the list
       visitedRefs.add(node._id);
     } catch (e) {

--- a/app/imports/api/creature/creatureProperties/methods/insertPropertyFromLibraryNode.js
+++ b/app/imports/api/creature/creatureProperties/methods/insertPropertyFromLibraryNode.js
@@ -14,6 +14,7 @@ import {
 import { reorderDocs } from '/imports/api/parenting/order.js';
 import { setDocToLastOrder } from '/imports/api/parenting/order.js';
 import fetchDocByRef from '/imports/api/parenting/fetchDocByRef.js';
+import { union } from 'lodash';
 
 const insertPropertyFromLibraryNode = new ValidatedMethod({
   name: 'creatureProperties.insertPropertyFromLibraryNode',
@@ -178,7 +179,7 @@ function reifyNodeReferences(nodes, visitedRefs = new Set(), depth = 0) {
     try {
       referencedNode = fetchDocByRef(node.ref);
       referencedNode.order = node.order;
-      referencedNode.tags = [...new Set(referencedNode.tags.concat(node.tags ?? []))];
+      referencedNode.tags = union(node.tags, referencedNode.tags);
       // We are definitely replacing this node, so add it to the list
       visitedRefs.add(node._id);
     } catch (e) {


### PR DESCRIPTION
As discussed on Discord, see [feature request](https://discord.com/channels/120762305087668224/1122212397311070360).

With this change, sheet tags on Reference properties will be added to the referenced property's sheet tags on insert. Duplicate tags will be ignored, and library tags will be unchanged since they're not used after insert.