### PR TITLE
Add mode to folder group cards to show top-level child list

### DIFF
--- a/app/imports/api/properties/Folders.js
+++ b/app/imports/api/properties/Folders.js
@@ -22,6 +22,10 @@ let FolderSchema = createPropertySchema({
     type: Boolean,
     optional: true,
   },
+  showChildList: {
+    type: Boolean,
+    optional: true,
+  },
   tab: {
     type: String,
     optional: true,

--- a/app/imports/client/ui/properties/components/folders/FolderGroupCard.vue
+++ b/app/imports/client/ui/properties/components/folders/FolderGroupCard.vue
@@ -10,6 +10,7 @@
       </v-subheader>
       <component
         :is="prop.type"
+        v-if="!model.showChildList"
         v-for="prop in properties"
         :key="prop._id"
         :model="prop"
@@ -19,23 +20,48 @@
         @sub-click="e => $emit('sub-click', e)"
         @remove="id => $emit('remove', id || prop._id)"
       />
+      <tree-node
+        v-if="model.showChildList"
+        v-for="prop in properties"
+        :key="prop._id"
+        class="item"
+        :node="prop"
+        :children="[]"
+        :start-expanded="true"
+        @selected="selectChildListProperty"
+      />
     </v-card>
   </div>
 </template>
 
 <script lang="js">
 import CreatureProperties from '/imports/api/creature/creatureProperties/CreatureProperties.js';
+import TreeNode from '/imports/client/ui/components/tree/TreeNode.vue';
 import propComponents from '/imports/client/ui/properties/components/folders/propertyComponentIndex.js';
 
 export default {
+  components: { TreeNode, ...propComponents },
   props: {
     model: {
       type: Object,
       required: true,
+    },
+    collection: {
+      type: String,
+      default: 'creatureProperties'
     }
   },
-  beforeCreate() {
-    Object.assign(this.$options.components, propComponents);
+  methods: {
+    selectChildListProperty(_id){
+      this.$store.commit('pushDialogStack', {
+        component: 'creature-property-dialog',
+        elementId: `tree-node-${_id}`,
+        data: {
+          _id,
+          startInEditTab: this.editing,
+        },
+      });
+    },
   },
   meteor: {
     properties() {
@@ -43,23 +69,25 @@ export default {
       CreatureProperties.find({
         'parent.id': this.model._id,
         removed: { $ne: true },
-        overridden: { $ne: true },
-        $or: [
-          {
-            type: 'toggle',
-            showUI: true,
-            deactivatedByAncestor: { $ne: true },
-            deactivatedByToggle: { $ne: true },
-          },
-          {
-            type: { $ne: 'toggle' },
-            inactive: { $ne: true }
-          },
-        ],
-        $nor: [
-          { hideWhenTotalZero: true, total: 0 },
-          { hideWhenValueZero: true, value: 0 },
-        ],
+        ...(this.model.showChildList ? {} : {
+          overridden: { $ne: true },
+          $or: [
+            {
+              type: 'toggle',
+              showUI: true,
+              deactivatedByAncestor: { $ne: true },
+              deactivatedByToggle: { $ne: true },
+            },
+            {
+              type: { $ne: 'toggle' },
+              inactive: { $ne: true }
+            },
+          ],
+          $nor: [
+            { hideWhenTotalZero: true, total: 0 },
+            { hideWhenValueZero: true, value: 0 },
+          ],
+        })
       }, {
         sort: { order: 1 },
       }).forEach(prop => {

--- a/app/imports/client/ui/properties/forms/FolderForm.vue
+++ b/app/imports/client/ui/properties/forms/FolderForm.vue
@@ -23,6 +23,12 @@
               :error-messages="errors.hideStatsGroup"
               @change="change('hideStatsGroup', ...arguments)"
             />
+            <smart-switch
+              label="Show child list instead of child cards"
+              :value="model.showChildList"
+              :error-messages="errors.showChildList"
+              @change="change('showChildList', ...arguments)"
+            />
             <smart-select
               clearable
               label="Tab"


### PR DESCRIPTION
As requested on Discord, see [feature request](https://discord.com/channels/120762305087668224/1140425080933978163).

Adds a new option to grouped folders that replaces the grouped display of property cards with a list of the folder's top-level children, constructed in much the same way as the list of children on a property viewer.

I've been very careful to avoid impacting any existing behavior of folder group cards. This is purely a new functionality mode, and does not touch any previous functionality outside of trivial internal refactors.

![image](https://github.com/ThaumRystra/DiceCloud/assets/45317150/476549dd-3309-4b64-8b39-bc6464a41cae)