### PR TITLE
Fix erroring functions causing a compile error

### DIFF
--- a/app/imports/parser/parseTree/call.js
+++ b/app/imports/parser/parseTree/call.js
@@ -104,12 +104,12 @@ const call = {
         // Resolve the return value
         return resolve(fn, value, scope, context);
       }
-    } catch (error) {
-      context.error(error.message || error);
+    } catch (err) {
+      context.error(`Internal error: ${err.message || err}`);
       return {
         result: error.create({
           node: node,
-          error: error.message || error,
+          error: `Internal error: ${err.message || err}`,
         }),
         context,
       }


### PR DESCRIPTION
If a function's implementation creates a Javascript error, it would return as a compile error due to the `error` variable being shadowed internally by this try-catch. This commit fixes that, as well as clarifies the fixed error messages with "internal error".