### PR TITLE
Add buff feature "Hide from stat tab"

### DIFF
--- a/app/imports/api/properties/Buffs.js
+++ b/app/imports/api/properties/Buffs.js
@@ -39,6 +39,11 @@ let BuffSchema = createPropertySchema({
     type: Boolean,
     optional: true,
   },
+  // Hide from normal stats tab location
+  hideStatTab: {
+    type: Boolean,
+    optional: true,
+  },
 });
 
 let ComputedOnlyBuffSchema = createPropertySchema({

--- a/app/imports/client/ui/creature/character/characterSheetTabs/StatsTab.vue
+++ b/app/imports/client/ui/creature/character/characterSheetTabs/StatsTab.vue
@@ -71,14 +71,14 @@
       />
 
       <div
-        v-if="properties.buff && properties.buff.length"
+        v-if="properties.buff && shownBuffs.length"
         class="buffs"
       >
         <v-card>
           <v-list>
             <v-subheader>Buffs and conditions</v-subheader>
             <buff-list-item
-              v-for="buff in properties.buff"
+              v-for="buff in shownBuffs"
               :key="buff._id"
               :data-id="buff._id"
               :model="buff"
@@ -515,6 +515,9 @@ export default {
       });
       return uniqBy(conditionals, '_id');
     },
+    shownBuffs(){
+      return this.properties.buff.filter(buff => !buff.hideStatTab);
+    }
   },
   meteor: {
     properties() {

--- a/app/imports/client/ui/properties/forms/BuffForm.vue
+++ b/app/imports/client/ui/properties/forms/BuffForm.vue
@@ -39,30 +39,28 @@
       </form-section>
       <form-section name="Behavior">
         <v-row dense>
-          <v-col
-            cols="12"
-            sm="6"
-            md="4"
-          >
-            <smart-switch
-              label="Hide remove button"
-              :value="model.hideRemoveButton"
-              :error-messages="errors.hideRemoveButton"
-              @change="change('hideRemoveButton', ...arguments)"
-            />
-          </v-col>
-          <v-col
-            cols="12"
-            sm="6"
-            md="4"
-          >
-            <smart-switch
-              label="Don't freeze variables"
-              :value="model.skipCrystalization"
-              :error-messages="errors.skipCrystalization"
-              @change="change('skipCrystalization', ...arguments)"
-            />
-          </v-col>
+          <smart-switch 
+            label="Hide remove button" 
+            :value="model.hideRemoveButton"
+            :error-messages="errors.hideRemoveButton" 
+            @change="change('hideRemoveButton', ...arguments)" 
+          />
+        </v-row>
+        <v-row dense>
+          <smart-switch 
+            label="Don't freeze variables" 
+            :value="model.skipCrystalization"
+            :error-messages="errors.skipCrystalization" 
+            @change="change('skipCrystalization', ...arguments)" 
+          />
+        </v-row>
+        <v-row dense>
+          <smart-switch 
+            label="Hide from stat tab" 
+            :value="model.hideStatTab" 
+            :error-messages="errors.hideStatTab"
+            @change="change('hideStatTab', ...arguments)" 
+          />
         </v-row>
       </form-section>
       <form-section name="Log">


### PR DESCRIPTION
## Why add this feature?
There are times where a user needs to have a more permanent part of a sheet removed. The example I'm drawn to is the spell scroll, which disintegrates upon use. Currently, the best implementations of this is to use a buff, which while functional, is unsightly on the stats tab. Hence this PR, adding the ability to conceal buffs from that space
[Example of what I'm referring to](https://dicecloud.com/character/QWtfafpZfGyfTYFsC/Spell-scroll-example)

## Implementation notes
- I haven't added a new field to a property before, but this should be backwards compatible since the boolean isn't required in the buff schema
- I rearranged the buff's behavior collapsible area, stacking the smart switches vertically
  - [image](https://github.com/ThaumRystra/DiceCloud/assets/24283273/8f5a9b11-3204-4a79-9bda-7c571622bb00)
  - I also considered a grid arrangement, but I don't really know how to do that in Vue
- I freely admit that it would be preferable to remove the item directly for my listed use case, but I struggled enough with this and have no idea how to go about adding a whole new system like that