### PR TITLE
Proposal: Depleted items section of inventory tab

### DIFF
--- a/app/imports/client/ui/creature/character/characterSheetTabs/InventoryTab.vue
+++ b/app/imports/client/ui/creature/character/characterSheetTabs/InventoryTab.vue
@@ -87,6 +87,7 @@
           </v-card-text>
         </toolbar-card>
       </div>
+      <!-- Proposal would implement a third calculated card here, with an alternative item-list that does not permit dragging, and includes an easy delete feature -->
       <div
         v-for="container in containersWithoutAncestorContainers"
         :key="container._id"

--- a/app/imports/client/ui/creature/character/characterSheetTabs/InventoryTab.vue
+++ b/app/imports/client/ui/creature/character/characterSheetTabs/InventoryTab.vue
@@ -194,7 +194,7 @@ export default {
         sort: { order: 1 },
       });
     },
-    carriedItems() {
+    carriedItems() { //Would modify to remove items w/ quantity=0
       return CreatureProperties.find({
         'ancestors.id': {
           $eq: this.creatureId,
@@ -212,7 +212,7 @@ export default {
         sort: { order: 1 },
       });
     },
-    equippedItems() {
+    equippedItems() {//Would modify to remove items w/ quantity=0
       return CreatureProperties.find({
         'ancestors.id': {
           $eq: this.creatureId,
@@ -244,7 +244,7 @@ export default {
         id: this.creatureId,
         collection: 'creatures'
       };
-    },
+    }, // Would add new calculated field for items w/ quantity=0, for use in depleted list
   },
   computed: {
     containerIds() {

--- a/app/imports/client/ui/properties/components/inventory/ItemList.vue
+++ b/app/imports/client/ui/properties/components/inventory/ItemList.vue
@@ -1,3 +1,4 @@
+<!-- Proposal would include a new template that's similar to an item-list, but doesn't care about a parent folder and has an easy delete button -->
 <template lang="html">
   <v-list
     dense


### PR DESCRIPTION
## What is this feature?
[Mockup](https://github.com/ThaumRystra/DiceCloud/assets/24283273/36a0341f-ce39-4451-90e2-b5edeab4f834)
A separate card for items who's quantity has hit zero, with a quick-trash button 

This feature does _not_ add a new folder to the creature's tree. All items will remain in their containers, but presented to the player in a modified way for clarity

## Why should this feature be implemented?
It is not currently possible to implement a self-removing item, and not a feature that will be implemented. However, I'm not personally happy with the state of items that should consume themselves, like spell scrolls. This feature aims to improve that by making it easier to remove items that have been "used up"

As a bonus, this also makes it much more obvious what items a creature actually "has" in the abstract sense. 