### PR TITLE
Add ~ammo

### DIFF
--- a/app/imports/api/engine/actions/applyPropertyByType/applyAction.js
+++ b/app/imports/api/engine/actions/applyPropertyByType/applyAction.js
@@ -13,8 +13,16 @@ import { getPropertyDecendants } from '/imports/api/engine/loadCreatures.js';
 import { nodeArrayToTree } from '/imports/api/parenting/nodesToTree.js';
 
 export default function applyAction(node, actionContext) {
-  applyNodeTriggers(node, 'before', actionContext);
   const prop = node.node;
+  const scope = actionContext.scope;
+
+  let ammo = scope['~ammo'] = [];
+  for (var i = 0; i < prop.resources.itemsConsumed.length; i++) {
+    const itemConsumed = prop.resources.itemsConsumed[i];
+    ammo.push({tag:itemConsumed.tag, item:itemConsumed.itemId && CreatureProperties.findOne(itemConsumed.itemId)});
+  }
+
+  applyNodeTriggers(node, 'before', actionContext);
   if (prop.target === 'self') actionContext.targets = [actionContext.creature];
   const targets = actionContext.targets;
 
@@ -51,6 +59,7 @@ export default function applyAction(node, actionContext) {
   if (prop.actionType === 'event' && prop.variableName) {
     resetProperties(actionContext.creature._id, prop.variableName, actionContext);
   }
+  delete actionContext.scope['~ammo'];
 }
 
 function applyAttackWithoutTarget({ attack, actionContext }) {


### PR DESCRIPTION
Adds ~ammo, an array of {tag, item} (where the index is a zero-indexed number in the list of items consumed) to the action context, including triggers before and after. See [feature request](https://discord.com/channels/120762305087668224/1146254259877322792)