### PR TITLE
Add ability to ignore uniqueness of chosen library properties

### DIFF
--- a/app/imports/api/library/LibraryNodes.js
+++ b/app/imports/api/library/LibraryNodes.js
@@ -59,6 +59,12 @@ let LibraryNodeSchema = new SimpleSchema({
     optional: true,
     index: 1,
   },
+  // Will this property ignore uniqueness when being inserted into slots
+  slotIgnoreUniqueness: {
+    type: Boolean,
+    optional: true,
+    index: 1,
+  },
   libraryTags: {
     type: Array,
     optional: true,

--- a/app/imports/client/ui/creature/slots/SlotFillDialog.vue
+++ b/app/imports/client/ui/creature/slots/SlotFillDialog.vue
@@ -84,6 +84,7 @@
                     v-model="selectedNodeIds"
                     class="my-0 py-0"
                     hide-details
+                    :input-value="alreadyAdded.has(libraryNode._id)"
                     :color="libraryNode._disabledBySlotFillerCondition ? 'error' : ''"
                     :disabled="isDisabled(libraryNode)"
                     :value="libraryNode._id"
@@ -345,7 +346,7 @@ export default {
       });
     },
     isDisabled(node) {
-      return node._disabledByAlreadyAdded ||
+      return (node._disabledByAlreadyAdded && !node.slotIgnoreUniqueness) ||
         (
           node._disabledByQuantityFilled &&
           !this.selectedNodeIds.includes(node._id)
@@ -485,8 +486,9 @@ export default {
       if (!this.libraryNodeFilter) return [];
       if (!this.$subReady.slotFillers) return [];
       let nodes = LibraryNodes.find(this.libraryNodeFilter, {
-        sort: { name: 1, order: 1 }
-      }).fetch();
+        sort: { name: 1, order: 1 },
+        reactive:false
+      });
       let disabledNodeCount = 0;
       // Mark slotFillers whose condition isn't met or are too big to fit
       // the quantity to fill
@@ -524,7 +526,7 @@ export default {
           node._disabled = true;
           node._disabledByQuantityFilled = true;
         }
-        if (this.alreadyAdded.has(node._id)) {
+        if (this.alreadyAdded.has(node._id) && !node.slotIgnoreUniqueness) {
           node._disabled = true;
           node._disabledByAlreadyAdded = true;
         }

--- a/app/imports/client/ui/properties/PropertyForm.vue
+++ b/app/imports/client/ui/properties/PropertyForm.vue
@@ -40,7 +40,7 @@
         >
           <v-col
             cols="12"
-            md="6"
+            md="4"
           >
             <smart-switch
               label="Can fill slots"
@@ -51,13 +51,24 @@
           </v-col>
           <v-col
             cols="12"
-            md="6"
+            md="4"
           >
             <smart-switch
               label="Searchable from character sheet"
               :value="model.searchable"
               :error-messages="errors.searchable"
               @change="(value, ack) => $emit('change', {path: ['searchable'], value, ack})"
+            />
+          </v-col>
+          <v-col
+            cols="12"
+            md="4"
+          >
+            <smart-switch
+              label="Ignores uniqueness requirements"
+              :value="model.slotIgnoreUniqueness"
+              :error-messages="errors.slotIgnoreUniqueness"
+              @change="(value, ack) => $emit('change', {path: ['slotIgnoreUniqueness'], value, ack})"
             />
           </v-col>
           <v-col


### PR DESCRIPTION
Adds a toggle to library items to allow them to ignore the uniqueness setting of the slot it's being used to fill. See [feature request](https://discord.com/channels/120762305087668224/1152091933062213732).