### PR TITLE
Fixes incorrect comment in Containers.js

### DIFF
--- a/app/imports/api/properties/Containers.js
+++ b/app/imports/api/properties/Containers.js
@@ -39,7 +39,7 @@ const ComputedOnlyContainerSchema = createPropertySchema({
     type: 'computedOnlyInlineCalculationField',
     optional: true,
   },
-  // Weight of all the contents, zero if `contentsWeightless` is true
+  // Weight of all the contents.
   contentsWeight: {
     type: Number,
     optional: true,


### PR DESCRIPTION
I don't know which way this bug goes, but right now the comment on `contentsWeight` says it's 0 if contentsWeightless is checked. This isn't the case (however carriedWeight does follow this rule)