### PR TITLE
Add Auto Archiving of Creatures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER mt
 RUN curl https://install.meteor.com/ | sh
 
 WORKDIR /home/mt
-RUN git clone https://github.com/ThaumRystra/DiceCloud dicecloud
+RUN git clone https://github.com/LinuxMaster393/DiceCloud dicecloud
 WORKDIR /home/mt/dicecloud/app
 RUN npm install --production
 ENV PATH=$PATH:/home/mt/.meteor

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ USER mt
 RUN curl https://install.meteor.com/ | sh
 
 WORKDIR /home/mt
-RUN git clone https://github.com/LinuxMaster393/DiceCloud dicecloud
+RUN git clone https://github.com/ThaumRystra/DiceCloud dicecloud
 WORKDIR /home/mt/dicecloud/app
 RUN npm install --production
 ENV PATH=$PATH:/home/mt/.meteor

--- a/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
+++ b/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
@@ -9,6 +9,7 @@ import CreatureProperties from '/imports/api/creature/creatureProperties/Creatur
 import CreatureLogs from '/imports/api/creature/log/CreatureLogs';
 import Experiences from '/imports/api/creature/experience/Experiences';
 import { removeCreatureWork } from '/imports/api/creature/creatures/methods/removeCreature';
+import { toSoftArchive } from '/imports/api/creature/archive/methods/softArchiveCreature';
 import ArchiveCreatureFiles from '/imports/api/creature/archive/ArchiveCreatureFiles';
 import { getFilter } from '/imports/api/parenting/parentingFunctions';
 
@@ -53,7 +54,11 @@ export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creat
       callback(error);
     } else if (!Meteor.settings.useS3) {
       // If we aren't using s3, remove the creature and call the callback
-      removeCreatureWork(creatureId);
+      if (autoArchive) {
+        toSoftArchive(creatureId, fileRef._id);
+      } else {
+        removeCreatureWork(creatureId);
+      }
       callback();
     } else {
       // Wait for s3Result event that occurs when the s3 attempt to write ends.
@@ -65,7 +70,11 @@ export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creat
         ArchiveCreatureFiles.off('s3Result', resultHandler);
         // Remove the creature if there was no error
         if (!s3Error) {
-          removeCreatureWork(creatureId);
+          if (autoArchive) {
+            toSoftArchive(creatureId, fileRef._id);
+          } else {
+            removeCreatureWork(creatureId);
+          }
         }
         // Alert the callback that we're done
         callback(s3Error);
@@ -74,6 +83,26 @@ export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creat
     }
   }, true);
 });
+
+export function softArchiveToArchive(creatureId) {
+  let creature = Creatures.findOne({ _id: creatureId });
+  Creatures.remove({ _id: creatureId });
+  ArchiveCreatureFiles.update(
+    { 
+      _id: creature.archiveId,
+      'meta.creatureId': creature._id,
+      'meta.auto': true,
+    },
+    {
+      $set: { 'meta.auto': false },
+    }, error => {
+      this.archiveActionLoading = false;
+      if (!error) return;
+      console.error(error);
+      snackbar({text: error.reason});
+    }
+  );
+}
 
 const archiveCreatureToFile = new ValidatedMethod({
   name: 'Creatures.methods.archiveCreatureToFile',
@@ -91,7 +120,12 @@ const archiveCreatureToFile = new ValidatedMethod({
   async run({ creatureId }) {
     assertOwnership(creatureId, this.userId);
     if (Meteor.isServer) {
-      archiveCreature(creatureId, false);
+      let creature = Creatures.findOne({ _id: creatureId }, { fields: { archiveId: 1 }});
+      if (creature.archiveId) {
+        softArchiveToArchive(creatureId);
+      } else {
+        archiveCreature(creatureId, false);
+      }
     } else {
       removeCreatureWork(creatureId);
     }

--- a/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
+++ b/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
@@ -34,7 +34,7 @@ export function getArchiveObj(creatureId) {
   return archiveCreature;
 }
 
-export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creatureId, callback) {
+export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creatureId, autoArchive, callback) {
   const archive = getArchiveObj(creatureId);
   const buffer = Buffer.from(JSON.stringify(archive, null, 2));
   ArchiveCreatureFiles.write(buffer, {
@@ -45,6 +45,7 @@ export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creat
       schemaVersion: SCHEMA_VERSION,
       creatureId: archive.creature._id,
       creatureName: archive.creature.name,
+      auto: !!autoArchive,
     },
   }, (error, fileRef) => {
     if (error) {
@@ -90,7 +91,7 @@ const archiveCreatureToFile = new ValidatedMethod({
   async run({ creatureId }) {
     assertOwnership(creatureId, this.userId);
     if (Meteor.isServer) {
-      archiveCreature(creatureId);
+      archiveCreature(creatureId, false);
     } else {
       removeCreatureWork(creatureId);
     }

--- a/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
+++ b/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
@@ -35,6 +35,7 @@ export function getArchiveObj(creatureId) {
 }
 
 export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creatureId, callback) {
+  console.log("Archiving creature " + creatureId);
   const archive = getArchiveObj(creatureId);
   const buffer = Buffer.from(JSON.stringify(archive, null, 2));
   ArchiveCreatureFiles.write(buffer, {

--- a/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
+++ b/app/imports/api/creature/archive/methods/archiveCreatureToFile.js
@@ -35,7 +35,6 @@ export function getArchiveObj(creatureId) {
 }
 
 export const archiveCreature = Meteor.wrapAsync(function archiveCreatureFn(creatureId, callback) {
-  console.log("Archiving creature " + creatureId);
   const archive = getArchiveObj(creatureId);
   const buffer = Buffer.from(JSON.stringify(archive, null, 2));
   ArchiveCreatureFiles.write(buffer, {

--- a/app/imports/api/creature/archive/methods/removeArchiveCreature.js
+++ b/app/imports/api/creature/archive/methods/removeArchiveCreature.js
@@ -2,6 +2,7 @@ import SimpleSchema from 'simpl-schema';
 import { ValidatedMethod } from 'meteor/mdg:validated-method';
 import { RateLimiterMixin } from 'ddp-rate-limiter-mixin';
 import ArchiveCreatureFiles from '/imports/api/creature/archive/ArchiveCreatureFiles';
+import Creatures from '/imports/api/creature/creatures/Creatures';
 import { incrementFileStorageUsed } from '/imports/api/users/methods/updateFileStorageUsed';
 
 const removeArchiveCreature = new ValidatedMethod({
@@ -29,6 +30,15 @@ const removeArchiveCreature = new ValidatedMethod({
     if (!userId || userId !== this.userId) {
       throw new Meteor.Error('Permission denied',
         'You can only restore creatures you own');
+    }
+    if (file.meta.auto) {
+      Creatures.remove(
+        {
+          _id: file.meta.creatureId,
+          owner: this.userId,
+          archiveId: file._id,
+        }
+      );
     }
     //Remove the archive once the restore succeeded
     ArchiveCreatureFiles.remove({ _id: fileId });

--- a/app/imports/api/creature/archive/methods/restoreCreatureFromFile.js
+++ b/app/imports/api/creature/archive/methods/restoreCreatureFromFile.js
@@ -101,4 +101,84 @@ const restoreCreaturefromFile = new ValidatedMethod({
   },
 });
 
+export const restoreSoftArchive = Meteor.wrapAsync(async function restoreSoftArchiveFn(creatureId, callback) {
+  if (!Meteor.isServer) return;
+
+  // Verify that the creature and archive match
+  const existingCreature = Creatures.findOne(
+    { _id: creatureId }, 
+    {
+      fields: { 
+        _id: 1,
+        owner: 1,
+        archiveId: 1,
+      },
+    }
+  );
+  if (!existingCreature) throw new Meteor.Error('Doesn\'t exist',
+    'The creature you are trying to restore doesn\'t exist');
+
+  if (!existingCreature.archiveId) throw new Meteor.Error('No Linked Archive',
+    'The creature doesn\'t have a linked archive.');
+
+  const archiveFile = ArchiveCreatureFiles.findOne({ 
+    _id: existingCreature.archiveId, 
+    userId: existingCreature.owner,
+    'meta.auto': true,
+    'meta.creatureId': creatureId,
+  });
+
+  const archive = await ArchiveCreatureFiles.readJSONFile(archiveFile);
+  
+  if (SCHEMA_VERSION < archive.meta.schemaVersion) {
+    throw new Meteor.Error('Incompatible',
+      'The archive file is from a newer version. Update required to read.')
+  }
+
+  // Migrate and verify the archive meets the current schema
+  migrateArchive(archive);
+
+  // Asset that the archive is safe
+  verifyArchiveSafety(archive);
+
+  try {
+    // Add all the properties
+    if (archive.properties && archive.properties.length) {
+      CreatureProperties.batchInsert(archive.properties);
+    }
+    if (archive.experiences && archive.experiences.length) {
+      Experiences.batchInsert(archive.experiences);
+    }
+    if (archive.logs && archive.logs.length) {
+      CreatureLogs.batchInsert(archive.logs);
+    }
+
+    Creatures.update(
+      { _id: creatureId },
+      { $unset: { 
+        archiveId: true,
+      }}
+    );
+  } catch (e) {
+    // If the above fails, delete the inserted creature
+    CreatureVariables.remove({ _creatureId: creatureId });
+    CreatureProperties.remove(getFilter.descendantsOfRoot(creatureId));
+    CreatureLogs.remove({ creatureId });
+    Experiences.remove({ creatureId });
+    Creatures.update(
+      { _id: creatureId },
+      { $set: { 
+        archiveId: archiveFile._id,
+      }}
+    );
+    console.log(e);
+    throw e;
+  }
+  //Remove the archive once the restore succeeded
+  ArchiveCreatureFiles.remove({ _id: archiveFile._id });
+  // Update the user's file storage limits
+  incrementFileStorageUsed(archiveFile.userId, -archiveFile.size);
+  callback();
+});
+
 export default restoreCreaturefromFile;

--- a/app/imports/api/creature/archive/methods/softArchiveCreature.js
+++ b/app/imports/api/creature/archive/methods/softArchiveCreature.js
@@ -1,0 +1,27 @@
+import Creatures from '/imports/api/creature/creatures/Creatures';
+import CreatureVariables from '/imports/api/creature/creatures/CreatureVariables';
+import CreatureProperties from '/imports/api/creature/creatureProperties/CreatureProperties';
+import CreatureLogs from '/imports/api/creature/log/CreatureLogs';
+import Experiences from '/imports/api/creature/experience/Experiences';
+import { getFilter } from '/imports/api/parenting/parentingFunctions';
+
+function removeRelatedDocuments(creatureId) {
+  CreatureVariables.remove({ _creatureId: creatureId });
+  CreatureProperties.remove(getFilter.descendantsOfRoot(creatureId));
+  CreatureLogs.remove({ creatureId });
+  Experiences.remove({ creatureId });
+}
+
+export function toSoftArchive(creatureId, archiveId) {
+  if (!Meteor.isServer) return;
+
+  Creatures.update(
+    { _id: creatureId },
+    {
+      $set: {
+        archiveId: archiveId,
+      },
+    }
+  );
+  removeRelatedDocuments(creatureId);
+}

--- a/app/imports/api/creature/creatures/Creatures.ts
+++ b/app/imports/api/creature/creatures/Creatures.ts
@@ -180,6 +180,12 @@ const CreatureSchema = TypedSimpleSchema.from({
     type: CreatureSettingsSchema,
     defaultValue: {},
   },
+
+  // Was auto archived
+  'archiveId': {
+    type: String,
+    optional: true,
+  },
 })
   .extend(ColorSchema)
   .extend(SharingSchema);

--- a/app/imports/api/users/methods/updateFileStorageUsed.js
+++ b/app/imports/api/users/methods/updateFileStorageUsed.js
@@ -2,7 +2,6 @@ import { ValidatedMethod } from 'meteor/mdg:validated-method';
 import { RateLimiterMixin } from 'ddp-rate-limiter-mixin';
 import ArchiveCreatureFiles from '/imports/api/creature/archive/ArchiveCreatureFiles';
 import UserImages from '/imports/api/files/userImages/UserImages';
-const fileCollections = [ArchiveCreatureFiles, UserImages];
 
 const updateFileStorageUsed = new ValidatedMethod({
   name: 'users.recalculateFileStorageUsed',
@@ -33,10 +32,11 @@ export function updateFileStorageUsedWork(userId) {
   }
 
   let sum = 0;
-  fileCollections.forEach(collection => {
-    collection.find({ userId }, { fields: { size: 1 } }).forEach(file => {
-      sum += file.size;
-    });
+  ArchiveCreatureFiles.find({ userId }, { fields: { size: 1 } }).forEach(file => {
+    sum += file.size;
+  });
+  UserImages.find({ userId }, { fields: { size: 1 } }).forEach(file => {
+    sum += file.size;
   });
 
   Meteor.users.update(userId, {

--- a/app/imports/client/ui/creature/archive/ArchiveDialog.vue
+++ b/app/imports/client/ui/creature/archive/ArchiveDialog.vue
@@ -27,8 +27,8 @@
       selection
       :creatures="mode === 'archive' ? CreaturesWithNoParty : archiveCreaturesWithNoParty"
       :folders="mode === 'archive' ? folders : archivefolders"
-      :selected-creature="selectedCreature"
-      @creature-selected="id => selectedCreature = id"
+      :selected-creature-id="selectedCreatureId"
+      @creature-selected="id => selectedCreatureId = id"
     />
     <v-spacer slot="actions" />
     <v-btn
@@ -94,6 +94,7 @@ const creatureFields = {
   'readers': 1,
   'writers': 1,
   'owner': 1,
+  'archiveId': 1,
 };
 
 export default {
@@ -102,36 +103,36 @@ export default {
     CreatureFolderList,
   },
   data(){return {
-    selectedCreature: null,
+    selectedCreatureId: null,
     mode: 'archive',
     archiveActionLoading: false,
   }},
   computed: {
     numSelected(){
-      return this.selectedCreature ? 1 : 0;
+      return this.selectedCreatureId ? 1 : 0;
     },
   },
   watch: {
     mode(){
-      this.selectedCreature = null;
+      this.selectedCreatureId = null;
     },
   },
   methods: {
     archiveAction(){
-      if (!this.selectedCreature) return;
+      if (!this.selectedCreatureId) return;
       this.archiveActionLoading = true;
-      if (this.mode === 'archive'){
+      if (this.mode === 'archive') {
         archiveCreatureToFile.call({
-          creatureId: this.selectedCreature,
+          creatureId: this.selectedCreatureId,
         }, error => {
           this.archiveActionLoading = false;
           if (!error) return;
           console.error(error);
           snackbar({text: error.reason});
         });
-      } else if (this.mode === 'restore'){
+      } else if (this.mode === 'restore') {
         restoreCreatureFromFile.call({
-          fileId: this.selectedCreature,
+          fileId: this.selectedCreatureId,
         }, error => {
           this.archiveActionLoading = false;
           if (!error) return;
@@ -139,7 +140,7 @@ export default {
           snackbar({text: error.reason});
         });
       }
-      this.selectedCreature = null;
+      this.selectedCreatureId = null;
     }
   },
   meteor: {
@@ -194,6 +195,10 @@ export default {
         folder.creatures = ArchiveCreatureFiles.find(
           {
             'meta.creatureId': {$in: folder.creatures || []},
+            $or: [
+              { 'meta.auto': false },
+              { 'meta.auto': { $exists: false } },
+            ],
             userId,
           }, {
             sort: {'meta.creatureName': 1},
@@ -211,6 +216,10 @@ export default {
       return ArchiveCreatureFiles.find(
         {
           'meta.creatureId': {$nin: folderChars},
+          $or: [
+            { 'meta.auto': false },
+            { 'meta.auto': { $exists: false } },
+          ],
           userId,
         }, {
           sort: {'meta.creatureName': 1},

--- a/app/imports/client/ui/creature/creatureList/CreatureFolderList.vue
+++ b/app/imports/client/ui/creature/creatureList/CreatureFolderList.vue
@@ -8,7 +8,7 @@
     <creature-list
       :creatures="creatures"
       :selection="selection"
-      :selected-creature="selectedCreature"
+      :selected-creature-id="selectedCreatureId"
       :dense="dense"
       @creature-selected="id => $emit('creature-selected', id)"
     />
@@ -34,7 +34,7 @@
           :creatures="folder.creatures"
           :folder-id="folder._id"
           :selection="selection"
-          :selected-creature="selectedCreature"
+          :selected-creature-id="selectedCreatureId"
           :dense="dense"
           @creature-selected="id => $emit('creature-selected', id)"
         />
@@ -62,7 +62,7 @@ export default {
       default: () => [],
     },
     selection: Boolean,
-    selectedCreature: {
+    selectedCreatureId: {
       type: String,
       default: undefined,
     },

--- a/app/imports/client/ui/creature/creatureList/CreatureList.vue
+++ b/app/imports/client/ui/creature/creatureList/CreatureList.vue
@@ -15,7 +15,7 @@
       class="creature"
       :model="creature"
       :selection="selection"
-      :is-selected="selectedCreatureId === creature._id || selectedCreatureIds.has(creature)"
+      :is-selected="selectedCreatureId === creature._id || selectedCreatureIds.has(creature._id)"
       v-bind="selection ? {} : {to: creature.url}"
       :dense="dense"
       :data-id="dense ? undefined : creature._id"

--- a/app/imports/client/ui/creature/creatureList/CreatureList.vue
+++ b/app/imports/client/ui/creature/creatureList/CreatureList.vue
@@ -15,7 +15,7 @@
       class="creature"
       :model="creature"
       :selection="selection"
-      :is-selected="selectedCreature === creature._id || selectedCreatures.has(creature._id)"
+      :is-selected="selectedCreatureId === creature._id || selectedCreatureIds.has(creature)"
       v-bind="selection ? {} : {to: creature.url}"
       :dense="dense"
       :data-id="dense ? undefined : creature._id"
@@ -45,11 +45,11 @@
         default: null,
       },
       selection: Boolean,
-      selectedCreature: {
+      selectedCreatureId: {
         type: String,
         default: undefined,
       },
-      selectedCreatures: {
+      selectedCreatureIds: {
         type: Set,
         default: () => new Set(),
       },

--- a/app/imports/client/ui/files/ArchiveFileCard.vue
+++ b/app/imports/client/ui/files/ArchiveFileCard.vue
@@ -4,16 +4,23 @@
       {{ model.meta.creatureName }}
     </v-card-title>
     <v-card-subtitle>
-      {{ model.size }}
+      {{ model.size }} {{ model.meta.auto ? "(Automatically Archived)" : ""}}
     </v-card-subtitle>
     <v-card-actions>
       <v-btn
-        v-if="characterSlots > 0"
+        v-if="characterSlots > 0 && !model.meta.auto"
         text
         :loading="restoreLoading"
         @click="restore(model._id)"
       >
         Restore
+      </v-btn>
+      <v-btn
+        v-else-if="model.meta.auto"
+        text
+        :to="model.url"
+      >
+        Open
       </v-btn>
       <v-flex />
       <v-btn

--- a/app/imports/client/ui/pages/Files.vue
+++ b/app/imports/client/ui/pages/Files.vue
@@ -142,6 +142,7 @@ import { archiveSchema } from '/imports/api/creature/archive/ArchiveCreatureFile
 import migrateArchive from '/imports/migrations/archive/migrateArchive';
 import ImageField from '/imports/client/ui/properties/viewers/shared/ImageField.vue';
 import SmartImageInput from '/imports/client/ui/components/global/SmartImageInput.vue';
+import getCreatureUrlName from '/imports/api/creature/creatures/getCreatureUrlName';
 
 // TODO Mark files that don't have versions.${version}.meta.pipePath set as broken links
 // TODO show user images
@@ -180,6 +181,7 @@ export default {
       ).map(f => {
         f.size = prettyBytes(f.size);
         f.link = ArchiveCreatureFiles.link(f);
+        f.url = `/character/${f.meta.creatureId}/${getCreatureUrlName({ name: f.meta.creatureName })}`
         return f;
       });
     },

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -26,7 +26,7 @@ Meteor.startup(() => {
   SyncedCron.add({
     name: 'archiveOldCreatures',
     schedule: function (parser) {
-      return parser.text('every 1 hour');
+      return parser.text('every 2 minutes');
     },
     job: archiveOldCreatures,
   });

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -9,6 +9,7 @@ Meteor.startup(() => {
    * Archive all creatures older than the configured amount of days.
    */
   const archiveOldCreatures = function () {
+    console.log("archiver " + archiveAfterDays);
     if (typeof archiveAfterDays != 'number') {
       return;
     }

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -15,8 +15,11 @@ Meteor.startup(() => {
     }
     const now = new Date();
     const expire = new Date(now.getTime() - (archiveAfterDays * 24 * 60 * 60 * 1000));
+    console.log("archiving all creatures after " + expire);
     Creatures.find({ lastComputeTime: { $lt: expire }}, { _id: 1 }).forEach( creature => {
+      console.log("archiving " + creature._id);
       archiveCreature(creature._id, function (error) {
+        console.log("Archive callback")
         if (error) {
           console.error(JSON.stringify(error, null, 2));
         }

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -18,12 +18,7 @@ Meteor.startup(() => {
     console.log("archiving all creatures after " + expire);
     Creatures.find({ lastComputedAt: { $lt: expire }}, { _id: 1 }).forEach( creature => {
       console.log("archiving " + creature._id);
-      archiveCreature(creature._id, function (error) {
-        console.log("Archive callback")
-        if (error) {
-          console.error(JSON.stringify(error, null, 2));
-        }
-      });
+      archiveCreature(creature._id);
     });
   }
 

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -15,7 +15,7 @@ Meteor.startup(() => {
     const now = new Date();
     const expire = new Date(now.getTime() - (archiveAfterDays * 24 * 60 * 60 * 1000));
     Creatures.find({ lastComputedAt: { $lt: expire }}, { _id: 1 }).forEach( creature => {
-      archiveCreature(creature._id);
+      archiveCreature(creature._id, true);
     });
   }
 

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -1,0 +1,44 @@
+import Creatures from '/imports/api/creature/creatures/Creatures';
+import archiveCreature from '/imports/api/creature/archive/methods/archiveCreatureToFile';
+import { assertAdmin } from '/imports/api/sharing/sharingPermissions';
+import { SyncedCron } from 'meteor/littledata:synced-cron';
+const archiveAfterDays = !!Meteor.settings?.archiveAfterDays;
+
+Meteor.startup(() => {
+  /**
+   * Archive all creatures older than the configured amount of days.
+   */
+  const archiveOldCreatures = function () {
+    if (typeof archiveAfterDays != 'number') {
+      return;
+    }
+    const now = new Date();
+    const expire = new Date(now.getTime() - (archiveAfterDays * 24 * 60 * 60 * 1000));
+    Creatures.find({ lastComputeTime: { $lt: expire }}, { _id: 1 }).forEach( creature => {
+      archiveCreature(creature._id, function (error) {
+        if (error) {
+          console.error(JSON.stringify(error, null, 2));
+        }
+      });
+    });
+  }
+
+  SyncedCron.add({
+    name: 'archiveOldCreatures',
+    schedule: function (parser) {
+      return parser.text('every 1 hour');
+    },
+    job: archiveOldCreatures,
+  });
+
+  SyncedCron.start();
+
+  // Add a method to manually trigger removal
+  Meteor.methods({
+    archiveOldCreatures() {
+      assertAdmin(this.userId);
+      this.unblock();
+      archiveOldCreatures();
+    },
+  });
+});

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -1,5 +1,5 @@
 import Creatures from '/imports/api/creature/creatures/Creatures';
-import archiveCreature from '/imports/api/creature/archive/methods/archiveCreatureToFile';
+import { archiveCreature } from '/imports/api/creature/archive/methods/archiveCreatureToFile';
 import { assertAdmin } from '/imports/api/sharing/sharingPermissions';
 import { SyncedCron } from 'meteor/littledata:synced-cron';
 const archiveAfterDays = Meteor.settings?.archiveAfterDays;

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -9,15 +9,12 @@ Meteor.startup(() => {
    * Archive all creatures older than the configured amount of days.
    */
   const archiveOldCreatures = function () {
-    console.log("archiver " + archiveAfterDays + " type: " + typeof archiveAfterDays);
     if (typeof archiveAfterDays != 'number') {
       return;
     }
     const now = new Date();
     const expire = new Date(now.getTime() - (archiveAfterDays * 24 * 60 * 60 * 1000));
-    console.log("archiving all creatures after " + expire);
     Creatures.find({ lastComputedAt: { $lt: expire }}, { _id: 1 }).forEach( creature => {
-      console.log("archiving " + creature._id);
       archiveCreature(creature._id);
     });
   }

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -22,7 +22,7 @@ Meteor.startup(() => {
   SyncedCron.add({
     name: 'archiveOldCreatures',
     schedule: function (parser) {
-      return parser.text('every 2 minutes');
+      return parser.text('every 10 minutes');
     },
     job: archiveOldCreatures,
   });

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -16,7 +16,7 @@ Meteor.startup(() => {
     const now = new Date();
     const expire = new Date(now.getTime() - (archiveAfterDays * 24 * 60 * 60 * 1000));
     console.log("archiving all creatures after " + expire);
-    Creatures.find({ lastComputeTime: { $lt: expire }}, { _id: 1 }).forEach( creature => {
+    Creatures.find({ lastComputedAt: { $lt: expire }}, { _id: 1 }).forEach( creature => {
       console.log("archiving " + creature._id);
       archiveCreature(creature._id, function (error) {
         console.log("Archive callback")

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -2,14 +2,14 @@ import Creatures from '/imports/api/creature/creatures/Creatures';
 import archiveCreature from '/imports/api/creature/archive/methods/archiveCreatureToFile';
 import { assertAdmin } from '/imports/api/sharing/sharingPermissions';
 import { SyncedCron } from 'meteor/littledata:synced-cron';
-const archiveAfterDays = !!Meteor.settings?.archiveAfterDays;
+const archiveAfterDays = Meteor.settings?.archiveAfterDays;
 
 Meteor.startup(() => {
   /**
    * Archive all creatures older than the configured amount of days.
    */
   const archiveOldCreatures = function () {
-    console.log("archiver " + archiveAfterDays);
+    console.log("archiver " + archiveAfterDays + " type: " + typeof archiveAfterDays);
     if (typeof archiveAfterDays != 'number') {
       return;
     }

--- a/app/imports/server/cron/archiveOldCreatures.js
+++ b/app/imports/server/cron/archiveOldCreatures.js
@@ -14,7 +14,7 @@ Meteor.startup(() => {
     }
     const now = new Date();
     const expire = new Date(now.getTime() - (archiveAfterDays * 24 * 60 * 60 * 1000));
-    Creatures.find({ lastComputedAt: { $lt: expire }}, { _id: 1 }).forEach( creature => {
+    Creatures.find({ lastComputedAt: { $lt: expire }, archiveId: { $exists: false } }, { _id: 1 }).forEach( creature => {
       archiveCreature(creature._id, true);
     });
   }

--- a/app/imports/server/publications/characterList.js
+++ b/app/imports/server/publications/characterList.js
@@ -34,6 +34,11 @@ Meteor.publish('characterList', function () {
           avatarPicture: 1,
           public: 1,
           type: 1,
+          archiveId: { $cond: {
+            if: "$archiveId",
+            then: true,
+            else: null,
+          }}
         }
       }
       ),

--- a/app/imports/server/publications/singleCharacter.js
+++ b/app/imports/server/publications/singleCharacter.js
@@ -9,6 +9,7 @@ import VERSION from '/imports/constants/VERSION';
 import { loadCreature } from '/imports/api/engine/loadCreatures';
 import { rebuildCreatureNestedSets } from '/imports/api/parenting/parentingFunctions';
 import EngineActions from '/imports/api/engine/action/EngineActions';
+import { restoreSoftArchive } from '/imports/api/creature/archive/methods/restoreCreatureFromFile';
 
 let schema = new SimpleSchema({
   creatureId: {
@@ -36,10 +37,14 @@ Meteor.publish('singleCharacter', function (creatureId) {
         public: 1,
         computeVersion: 1,
         tabletopId: 1,
+        archiveId: 1,
       }
     });
     try { assertViewPermission(permissionCreature, userId) }
     catch (e) { return [] }
+    if (permissionCreature && permissionCreature.archiveId) {
+      restoreSoftArchive(permissionCreature._id);
+    }
     loadCreature(creatureId, self);
     if (permissionCreature?.computeVersion !== VERSION && computation.firstRun) {
       try {

--- a/app/server/main.js
+++ b/app/server/main.js
@@ -8,6 +8,7 @@ import '/imports/server/config/SyncedCronConfig';
 import '/imports/server/config/redisCaching';
 import '/imports/server/publications/index';
 import '/imports/server/cron/deleteSoftRemovedDocuments';
+import '/imports/server/cron/archiveOldCreatures';
 import '/imports/api/parenting/organizeMethods';
 import '/imports/api/users/patreon/updatePatreonOnLogin';
 import '/imports/migrations/server/index';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - MONGO_URL=mongodb://meteor:meteor@dicecloud-db:27017
       - PORT=3000
       - NODE_ENV=production
-      - METEOR_SETTINGS={"public":{"environment":"production","disablePatreon":true}}
+      - METEOR_SETTINGS={"public":{"environment":"production","disablePatreon":true},"archiveAfterDays":1}
       - MAIL_URL=smtp://EMAIL:PASSWORD@SERVER:PORT
     ports:
       - '3000:3000' #The internal port should match the port set in the environmental variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,8 @@ services:
       - MONGO_URL=mongodb://meteor:meteor@dicecloud-db:27017
       - PORT=3000
       - NODE_ENV=production
-      - METEOR_SETTINGS={"public":{"environment":"production","disablePatreon":true},"archiveAfterDays":1}
+      - METEOR_SETTINGS={"public":{"environment":"production","disablePatreon":true},"archiveAfterDays":100}
       - MAIL_URL=smtp://EMAIL:PASSWORD@SERVER:PORT
     ports:
       - '3000:3000' #The internal port should match the port set in the environmental variables
+


### PR DESCRIPTION
Created a server cron job to check every 10 minutes for any creatures/characters that were updated more than archiveAfterDays ago and archive it, according to the "lastComputedAt" value on the creature. archiveAfterDays can be set in the meteor settings file or meteor settings environmental variable.

Tested using the docker compose file with build caching disabled and archiveAfterDays both set and unset.