### PR TITLE
refacto(docker): Download Node.js binaries directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,43 @@
-FROM ubuntu:jammy
+FROM debian:bookworm
 
-USER root
-RUN adduser --system mt
+ARG NODE_VERSION=14.21.3
+RUN test -n "$NODE_VERSION" || ( echo "NODE_VERSION build argument is not defined" >&2 && exit 1 )
 
-RUN apt-get update
-RUN apt-get install --quiet --yes curl
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get update
-RUN apt-get install --quiet --yes nodejs git
+RUN apt-get -y update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        xz-utils
 
+ENV PATH="/usr/local/node/bin:/usr/local/node/sbin:${PATH}"
+
+RUN arch="$( if [ "$(uname -m)" = "aarch64" ]; then echo "arm64"; else echo "x64"; fi )" && \
+	mkdir /usr/local/node && cd /usr/local/node && \
+    echo https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${arch}.tar.xz && \
+	curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${arch}.tar.xz | tar -xJ --strip-components=1
+
+RUN adduser --system --shell /bin/bash --home /home/mt/ mt
 USER mt
+WORKDIR /home/mt
 
 RUN curl https://install.meteor.com/ | sh
 
-WORKDIR /home/mt
-RUN git clone https://github.com/ThaumRystra/DiceCloud dicecloud
+WORKDIR /home/mt/dicecloud
+COPY --chown=mt ./app ./app
 WORKDIR /home/mt/dicecloud/app
+
 RUN npm install --production
-ENV PATH=$PATH:/home/mt/.meteor
+ENV PATH=${PATH}:/home/mt/.meteor
 RUN meteor build --directory ~/dc/ --architecture os.linux.x86_64
+
 WORKDIR /home/mt/dc/bundle/programs/server
 RUN npm install
+
 WORKDIR /home/mt/dc/bundle
 RUN rm -r /home/mt/dicecloud
 
-ENTRYPOINT node main.js
+COPY ./README.md ./
+COPY ./License.md ./
+
+ENTRYPOINT ["node", "main.js"]


### PR DESCRIPTION
- Bypasses the deprecation warning from the convenience script; which is a good QoL for end users.
- Prevent rebuild on any non meaningful-file change (by only copying ./app).
- Does not clone the repository *again*; which allows for forks and branching
- Also, upgrades uses Debian 12 as the base image; this can be changed to an equivalent Ubuntu one if desired. The way Node.js is installed here is resilient to this kind of image swap.
- While Meteor will not build for aarch64 *now*, the way Node.js is installed here will work for amd64 and aarch64.