### PR TITLE
Add internationalization (i18n) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+node_modules
+dicecloud  

--- a/app/imports/api/users/Users.js
+++ b/app/imports/api/users/Users.js
@@ -69,6 +69,11 @@ const userSchema = new SimpleSchema({
     type: Boolean,
     optional: true,
   },
+  language: {
+    type: String,
+    optional: true,
+    allowedValues: ['en', 'pt-br'],
+  },
   subscribedLibraries: {
     type: Array,
     defaultValue: defaultLibraries,
@@ -153,6 +158,22 @@ Meteor.users.setDarkMode = new ValidatedMethod({
   run({ darkMode }) {
     if (!this.userId) return;
     Meteor.users.update(this.userId, { $set: { darkMode } });
+  },
+});
+
+Meteor.users.setLanguage = new ValidatedMethod({
+  name: 'users.setLanguage',
+  validate: new SimpleSchema({
+    language: { type: String, allowedValues: ['en', 'pt-br'] },
+  }).validator(),
+  mixins: [RateLimiterMixin],
+  rateLimit: {
+    numRequests: 5,
+    timeInterval: 2000,
+  },
+  run({ language }) {
+    if (!this.userId) return;
+    Meteor.users.update(this.userId, { $set: { language } });
   },
 });
 

--- a/app/imports/client/ui/components/ColorPicker.vue
+++ b/app/imports/client/ui/components/ColorPicker.vue
@@ -86,14 +86,14 @@
           text
           @click="$emit('input')"
         >
-          Clear
+          {{ $t('components.colorPicker.clear') }}
         </v-btn>
         <v-spacer />
         <v-btn
           text
           @click="opened = false"
         >
-          Done
+          {{ $t('components.colorPicker.done') }}
         </v-btn>
       </v-card-actions>
     </v-card>

--- a/app/imports/client/ui/components/ResetSelector.vue
+++ b/app/imports/client/ui/components/ResetSelector.vue
@@ -1,6 +1,6 @@
 <template>
   <smart-select
-    label="Reset"
+    :label="$t('components.resetSelector.reset')"
     clearable
     style="flex-basis: 300px;"
     :hint="hint"
@@ -32,10 +32,10 @@ export default {
       }, true);
       const defaultEvents = [
         {
-          text: 'Short rest',
+          text: this.$t('components.resetSelector.shortRest'),
           value: 'shortRest',
         }, {
-          text: 'Long rest',
+          text: this.$t('components.resetSelector.longRest'),
           value: 'longRest',
         }
       ];

--- a/app/imports/client/ui/components/global/IconPicker.vue
+++ b/app/imports/client/ui/components/global/IconPicker.vue
@@ -41,7 +41,7 @@
         <div class="layout row align-center">
           <text-field
             ref="iconSearchField"
-            label="Search icons"
+            :label="$t('components.iconPicker.searchIcons')"
             append-icon="mdi-magnify"
             clearable
             hide-details
@@ -53,7 +53,7 @@
             text
             @click="select()"
           >
-            clear
+            {{ $t('components.iconPicker.clear') }}
           </v-btn>
         </div>
         <v-layout

--- a/app/imports/client/ui/components/global/SmartToggle.vue
+++ b/app/imports/client/ui/components/global/SmartToggle.vue
@@ -23,11 +23,16 @@
         v-on="(value == option.value) ? {} : { click() { click(option.value) } }"
       >
         <v-icon
-          v-if="option.icon"
+          v-if="option.icon && option.icon.startsWith('mdi-')"
           left
         >
           {{ option.icon }}
         </v-icon>
+        <span
+          v-else-if="option.icon"
+          class="mr-2"
+          style="font-size: 1.2em;"
+        >{{ option.icon }}</span>
         {{ option.name }}
       </v-btn>
     </v-btn-toggle>

--- a/app/imports/client/ui/components/propertyToolbar.vue
+++ b/app/imports/client/ui/components/propertyToolbar.vue
@@ -55,7 +55,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Help
+                  {{ $t('components.propertyToolbar.help') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -69,7 +69,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Duplicate
+                  {{ $t('components.propertyToolbar.duplicate') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -83,7 +83,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Copy To
+                  {{ $t('components.propertyToolbar.copyTo') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -97,7 +97,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Create Reference
+                  {{ $t('components.propertyToolbar.createReference') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -111,7 +111,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Move
+                  {{ $t('components.propertyToolbar.move') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -125,7 +125,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Copy to library
+                  {{ $t('components.propertyToolbar.copyToLibrary') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -139,7 +139,7 @@
             >
               <v-list-item-content>
                 <v-list-item-title>
-                  Delete
+                  {{ $t('components.propertyToolbar.delete') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -159,8 +159,9 @@
       outlined
       @click="$emit('toggle-editing')"
     >
-      <span style="width: 44px;">
-        {{ editing ? 'Done' : 'Edit' }}
+      <!-- Changed to fix-content because in PT the text is too long -->
+      <span style="width: fit-content;">
+        {{ editing ? $t('components.propertyToolbar.done') : $t('components.propertyToolbar.edit') }}
       </span>
       <v-slide-y-transition
         hide-on-leave

--- a/app/imports/client/ui/components/tree/TreeSearchInput.vue
+++ b/app/imports/client/ui/components/tree/TreeSearchInput.vue
@@ -22,13 +22,13 @@
 
     <v-card>
       <v-card-title>
-        Search
+        {{ $t('components.treeSearch.search') }}
       </v-card-title>
       <v-card-text>
         <v-select
           v-model="typeFilterInput"
           outlined
-          label="Type"
+          :label="$t('components.treeSearch.type')"
           :items="filterOptions"
           multiple
           clearable
@@ -44,12 +44,12 @@
             <v-text-field
               v-model="fieldFilter.field"
               class="text--mono"
-              label="Field"
+              :label="$t('components.treeSearch.field')"
               outlined
             />
             <v-text-field
               v-model="fieldFilter.value"
-              label="Text"
+              :label="$t('components.treeSearch.text')"
               class="ml-2"
               outlined
             />
@@ -86,7 +86,7 @@
             <v-icon left>
               mdi-close
             </v-icon>
-            Clear
+            {{ $t('components.treeSearch.clear') }}
           </v-btn>
           <v-spacer />
           <v-btn
@@ -94,7 +94,7 @@
             color="primary"
             @click="menu = false"
           >
-            Find
+            {{ $t('components.treeSearch.find') }}
           </v-btn>
         </v-card-actions>
       </v-card-text>

--- a/app/imports/client/ui/creature/CreatureForm.vue
+++ b/app/imports/client/ui/creature/CreatureForm.vue
@@ -1,21 +1,21 @@
 <template lang="html">
   <div class="creature-form">
     <text-field
-      label="Name"
+      :label="$t('creature.creatureForm.name')"
       :disabled="!editPermission"
       :value="model.name"
       :error-messages="errors.name"
       @change="(value, ack) => $emit('change', {path: ['name'], value, ack})"
     />
     <text-field
-      label="Alignment"
+      :label="$t('creature.creatureForm.alignment')"
       :disabled="!editPermission"
       :value="model.alignment"
       :error-messages="errors.alignment"
       @change="(value, ack) => $emit('change', {path: ['alignment'], value, ack})"
     />
     <text-field
-      label="Gender"
+      :label="$t('creature.creatureForm.gender')"
       :disabled="!editPermission"
       :value="model.gender"
       :error-messages="errors.gender"
@@ -27,8 +27,8 @@
         md="6"
       >
         <smart-image-input
-          label="Picture"
-          hint="A link to a high resolution image"
+          :label="$t('creature.creatureForm.picture')"
+          :hint="$t('creature.creatureForm.pictureHint')"
           :disabled="!editPermission"
           :value="model.picture"
           :error-messages="errors.picture"
@@ -40,8 +40,8 @@
         md="6"
       >
         <smart-image-input
-          label="Avatar"
-          hint="A link to a smaller, square image to use as an avatar"
+          :label="$t('creature.creatureForm.avatar')"
+          :hint="$t('creature.creatureForm.avatarHint')"
           :disabled="!editPermission"
           :value="model.avatarPicture"
           :error-messages="errors.avatarPicture"
@@ -50,34 +50,34 @@
       </v-col>
     </v-row>
     <form-sections>
-      <form-section name="Settings">
+      <form-section :name="$t('creature.creatureForm.settings')">
         <v-switch
-          label="Hide redundant stats"
+          :label="$t('creature.creatureForm.hideRedundantStats')"
           :disabled="!editPermission"
           :input-value="model.settings.hideUnusedStats"
           @change="value => $emit('change', {path: ['settings','hideUnusedStats'], value: !!value})"
         />
         <v-switch
-          label="Hide rest buttons"
+          :label="$t('creature.creatureForm.hideRestButtons')"
           :disabled="!editPermission"
           :input-value="model.settings.hideRestButtons"
           @change="value => $emit('change', {path: ['settings','hideRestButtons'], value: !!value})"
         />
         <v-switch
-          label="Show spells tab"
+          :label="$t('creature.creatureForm.showSpellsTab')"
           :disabled="!editPermission"
           :input-value="!model.settings.hideSpellsTab"
           @change="changeHideSpellsTab"
         />
         <v-switch
-          label="Show tree tab"
+          :label="$t('creature.creatureForm.showTreeTab')"
           :disabled="!editPermission"
           :input-value="model.settings.showTreeTab"
           @change="changeShowTreeTab"
         />
         <text-field
-          label="Hit Dice reset multiplier"
-          hint="What fraction of your hit dice are reset every long rest"
+          :label="$t('creature.creatureForm.hitDiceResetMultiplier')"
+          :hint="$t('creature.creatureForm.hitDiceResetHint')"
           placeholder="0.5"
           type="number"
           min="0"
@@ -88,8 +88,8 @@
           @change="(value, ack) => $emit('change', {path: ['settings','hitDiceResetMultiplier'], value, ack})"
         />
         <text-field
-          label="Discord Webhook URL"
-          hint="This creature's logs will be posted to the discord channel"
+          :label="$t('creature.creatureForm.discordWebhook')"
+          :hint="$t('creature.creatureForm.discordWebhookHint')"
           placeholder="https://discordapp.com/api/webhooks/<id>/<token>"
           :disabled="!editPermission"
           :value="model.settings.discordWebhook"
@@ -116,9 +116,9 @@
         />
         -->
       </form-section>
-      <form-section name="Libraries">
+      <form-section :name="$t('creature.creatureForm.libraries')">
         <smart-switch
-          label="All user libraries"
+          :label="$t('creature.creatureForm.allUserLibraries')"
           :disabled="!editPermission"
           :value="allUserLibraries"
           @change="allUserLibrariesChange"
@@ -144,7 +144,7 @@
           {{ libraryWriteError }}
         </p>
       </form-section>
-      <form-section name="Debug">
+      <form-section :name="$t('creature.creatureForm.debug')">
         <v-btn
           data-id="dependency-graph-button"
           text
@@ -153,7 +153,7 @@
           <v-icon left>
             mdi-graph
           </v-icon>
-          Dependency Graph
+          {{ $t('creature.creatureForm.dependencyGraph') }}
         </v-btn>
       </form-section>
     </form-sections>

--- a/app/imports/client/ui/creature/CreatureFormDialog.vue
+++ b/app/imports/client/ui/creature/CreatureFormDialog.vue
@@ -5,7 +5,7 @@
   >
     <template slot="toolbar">
       <v-toolbar-title>
-        Character Details
+        {{ $t('creature.creatureFormDialog.title') }}
       </v-toolbar-title>
       <v-spacer />
       <color-picker
@@ -27,7 +27,7 @@
       text
       @click="$store.dispatch('popDialogStack')"
     >
-      Done
+      {{ $t('creature.creatureFormDialog.done') }}
     </v-btn>
   </dialog-base>
 </template>

--- a/app/imports/client/ui/creature/RestButton.vue
+++ b/app/imports/client/ui/creature/RestButton.vue
@@ -10,7 +10,7 @@
     <v-icon left>
       {{ type === 'shortRest' ? 'mdi-music-rest-quarter' : 'mdi-bed' }}
     </v-icon>
-    {{ type === 'shortRest' ? 'Short Rest' : 'Long Rest' }}
+    {{ type === 'shortRest' ? $t('creature.restButton.shortRest') : $t('creature.restButton.longRest') }}
   </v-btn>
 </template>
 

--- a/app/imports/client/ui/creature/RestButton.vue
+++ b/app/imports/client/ui/creature/RestButton.vue
@@ -4,7 +4,7 @@
     :disabled="context.editPermission === false"
     outlined
     :data-id="`rest-btn-${type}`"
-    style="width: 160px;"
+    style="width: fit-content; min-width: 180px;"
     @click="rest"
   >
     <v-icon left>

--- a/app/imports/client/ui/creature/actions/ActionDialog.vue
+++ b/app/imports/client/ui/creature/actions/ActionDialog.vue
@@ -30,7 +30,7 @@
           class="done-button"
           @click="finishAction"
         >
-          Done
+          {{ $t('creature.actions.done') }}
         </v-btn>
       </v-card>
     </v-slide-x-reverse-transition>

--- a/app/imports/client/ui/creature/actions/input/AdvantageInput.vue
+++ b/app/imports/client/ui/creature/actions/input/AdvantageInput.vue
@@ -6,10 +6,10 @@
       @change="emitInput"
     >
       <v-btn :value="-1">
-        Disadvantage
+        {{ $t('creature.actions.input.advantageInput.disadvantage') }}
       </v-btn>
       <v-btn :value="1">
-        Advantage
+        {{ $t('creature.actions.input.advantageInput.advantage') }}
       </v-btn>
     </v-btn-toggle>
     <div style="position: relative;">
@@ -29,7 +29,7 @@
         @click="$emit('continue')"
       >
         <div>
-          Roll
+          {{ $t('creature.actions.input.advantageInput.roll') }}
         </div>
       </vertical-hex>
     </div>

--- a/app/imports/client/ui/creature/actions/input/CastSpellInput.vue
+++ b/app/imports/client/ui/creature/actions/input/CastSpellInput.vue
@@ -2,7 +2,7 @@
   <div>
     <text-field
       ref="focusFirst"
-      label="Name"
+      :label="$t('creature.actions.input.castSpellInput.fields.name')"
       prepend-inner-icon="mdi-magnify"
       regular
       hide-details
@@ -46,7 +46,7 @@
             text
             @click="clearBooleanFilters"
           >
-            Clear
+            {{ $t('creature.actions.input.castSpellInput.clear') }}
           </v-btn>
           <v-spacer />
           <v-btn
@@ -54,7 +54,7 @@
             class="primary--text"
             @click="filterMenuOpen = false"
           >
-            Done
+            {{ $t('creature.actions.input.castSpellInput.done') }}
           </v-btn>
         </div>
       </v-list>
@@ -65,7 +65,7 @@
           key="slot-title"
           class="text-h6 my-3"
         >
-          Slot
+          {{ $t('creature.actions.input.castSpellInput.slot') }}
         </div>
         <v-list-item-group
           key="slot-list"
@@ -81,7 +81,7 @@
           >
             <v-list-item-content>
               <v-list-item-title>
-                Cast without spell slot
+                {{ $t('creature.actions.input.castSpellInput.castWithoutSpellSlot') }}
               </v-list-item-title>
             </v-list-item-content>
           </v-list-item>
@@ -95,7 +95,7 @@
           >
             <v-list-item-content>
               <v-list-item-title>
-                Cast as ritual
+                {{ $t('creature.actions.input.castSpellInput.castAsRitual') }}
               </v-list-item-title>
             </v-list-item-content>
           </v-list-item>
@@ -116,7 +116,7 @@
           key="spell-title-right"
           class="text-h6 my-3"
         >
-          Spell
+          {{ $t('creature.actions.input.castSpellInput.spell') }}
         </div>
         <v-list-item-group
           key="slot-list-right"
@@ -128,7 +128,7 @@
               :key="`${spell.level}-header`"
               class="item"
             >
-              {{ spell.level === 0 ? 'Cantrips' : `Level ${spell.level}` }}
+              {{ spell.level === 0 ? $t('creature.actions.input.castSpellInput.cantrip') : $t('creature.actions.input.castSpellInput.level', { level: spell.level }) }}
             </v-subheader>
             <spell-list-tile
               v-else

--- a/app/imports/client/ui/creature/actions/input/CheckInput.vue
+++ b/app/imports/client/ui/creature/actions/input/CheckInput.vue
@@ -7,10 +7,10 @@
         @change="changeAdvantage"
       >
         <v-btn :value="-1">
-          Disadvantage
+          {{ $t('creature.actions.input.checkInput.disadvantage') }}
         </v-btn>
         <v-btn :value="1">
-          Advantage
+          {{ $t('creature.actions.input.checkInput.advantage') }}
         </v-btn>
       </v-btn-toggle>
       <div style="position: relative;">
@@ -30,26 +30,26 @@
           @click="$emit('continue')"
         >
           <div>
-            Roll
+            {{ $t('creature.actions.input.checkInput.roll') }}
           </div>
         </vertical-hex>
       </div>
     </div>
     <div class="d-flex flex-column mt-4 mr-4">
       <smart-select
-        label="Ability"
+        :label="$t('creature.actions.input.checkInput.select.ability')"
         :items="abilityOptions"
         :value="value.abilityVariableName"
         @change="change('abilityVariableName', ...arguments)"
       />
       <smart-select
-        label="Skill"
+        :label="$t('creature.actions.input.checkInput.select.skill')"
         :items="skillOptions"
         :value="value.skillVariableName"
         @change="change('skillVariableName', ...arguments)"
       />
       <text-field
-        label="DC"
+        :label="$t('creature.actions.input.checkInput.dc')"
         :value="value.dc"
         @change="change('dc', ...arguments)"
       />

--- a/app/imports/client/ui/creature/actions/input/ChoiceInput.vue
+++ b/app/imports/client/ui/creature/actions/input/ChoiceInput.vue
@@ -44,7 +44,7 @@
       :disabled="!canContinue"
       @click="$emit('continue');"
     >
-      Done
+      {{ $t('creature.actions.input.choiceInput.done') }}
     </v-btn>
   </div>
 </template>

--- a/app/imports/client/ui/creature/actions/input/TargetsInput.vue
+++ b/app/imports/client/ui/creature/actions/input/TargetsInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="choice-input">
     <v-card-title>
-      {{ target === 'singleTarget' ? 'Target' : 'Targets' }}
+      {{ target === 'singleTarget' ? $t('creature.actions.input.targetsInput.singleTarget') : $t('creature.actions.input.targetsInput.multipleTargets') }}
     </v-card-title>
     <v-list-item
       v-for="creature in creatures"
@@ -47,7 +47,7 @@
       style="width: 100%"
       @click="$emit('continue');"
     >
-      {{ !value.length ? 'No target' : 'Continue' }}
+      {{ !value.length ? $t('creature.actions.input.targetsInput.noTarget') : $t('creature.actions.input.targetsInput.continue') }}
     </v-btn>
   </div>
 </template>

--- a/app/imports/client/ui/creature/archive/ArchiveDialog.vue
+++ b/app/imports/client/ui/creature/archive/ArchiveDialog.vue
@@ -2,7 +2,7 @@
   <dialog-base>
     <template #toolbar>
       <v-toolbar-title>
-        {{ mode === 'archive' ? 'Archive' : 'Restore' }}
+        {{ mode === 'archive' ? $t('creature.archiveDialog.archive') : $t('creature.archiveDialog.restore') }}
       </v-toolbar-title>
       <v-spacer />
       <v-btn-toggle
@@ -10,13 +10,13 @@
         mandatory
       >
         <v-btn value="archive">
-          <span>Archive</span>
+          <span>{{ $t('creature.archiveDialog.archive') }}</span>
           <v-icon right>
             mdi-archive-arrow-down
           </v-icon>
         </v-btn>
         <v-btn value="restore">
-          <span>Restore</span>
+          <span>{{ $t('creature.archiveDialog.restore') }}</span>
           <v-icon right>
             mdi-archive-arrow-up-outline
           </v-icon>
@@ -43,7 +43,7 @@
         No Character Slots Left
       </template>
       <template v-else>
-        {{ mode === 'archive' ? 'Archive' : 'Restore' }}
+        {{ mode === 'archive' ? $t('creature.archiveDialog.archive') : $t('creature.archiveDialog.restore') }}
       </template>
     </v-btn>
     <v-btn
@@ -51,7 +51,7 @@
       text
       @click="$store.dispatch('popDialogStack')"
     >
-      Close
+      {{ $t('creature.archiveDialog.close') }}
     </v-btn>
   </dialog-base>
 </template>

--- a/app/imports/client/ui/creature/character/CharacterCreationDialog.vue
+++ b/app/imports/client/ui/creature/character/CharacterCreationDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      New Character
+      {{ $t('creature.character.characterCreationDialog.title') }}
     </v-toolbar-title>
     <v-stepper
       slot="unwrapped-content"
@@ -16,7 +16,7 @@
           step="1"
           :rules="[() => biographyAlert || true]"
         >
-          Biography
+          {{ $t('creature.character.characterCreationDialog.biography') }}
           <small v-if="biographyAlert">{{ biographyAlert }}</small>
         </v-stepper-step>
         <v-divider />
@@ -25,7 +25,7 @@
           :complete="step > 2"
           step="2"
         >
-          Libraries
+          {{ $t('creature.character.characterCreationDialog.libraries') }}
         </v-stepper-step>
       </v-stepper-header>
 
@@ -34,24 +34,24 @@
           <v-text-field
             v-model="name"
             outlined
-            label="Name"
+            :label="$t('creature.character.characterCreationDialog.fields.name')"
             class="mt-1"
             :error="!name"
           />
           <v-text-field
             v-model="alignment"
             outlined
-            label="Alignment"
+            :label="$t('creature.character.characterCreationDialog.fields.alignment')"
           />
           <v-text-field
             v-model="gender"
             outlined
-            label="Gender"
+            :label="$t('creature.character.characterCreationDialog.fields.gender')"
           />
           <v-text-field
             v-model.number="startingLevel"
             outlined
-            label="Level"
+            :label="$t('creature.character.characterCreationDialog.fields.level')"
             type="number"
             height="20"
             min="0"
@@ -61,7 +61,7 @@
         <v-stepper-content step="2">
           <v-switch
             v-model="allSubscribedLibraries"
-            label="All user libraries"
+            :label="$t('creature.character.characterCreationDialog.allUserLibraries')"
           />
           <library-list
             selection
@@ -80,14 +80,14 @@
         text
         @click="$emit('pop')"
       >
-        Cancel
+        {{ $t('creature.character.characterCreationDialog.cancel') }}
       </v-btn>
       <v-btn
         v-if="step > 1"
         text
         @click="step--"
       >
-        Back
+        {{ $t('creature.character.characterCreationDialog.back') }}
       </v-btn>
       <v-spacer />
       <v-btn
@@ -95,7 +95,7 @@
         color="accent"
         @click="step++"
       >
-        Next
+        {{ $t('creature.character.characterCreationDialog.next') }}
       </v-btn>
       <v-btn
         :disabled="!!biographyAlert"
@@ -103,7 +103,7 @@
         :color="step < 2? '' : 'accent'"
         @click="submit"
       >
-        Create
+        {{ $t('creature.character.characterCreationDialog.create') }}
       </v-btn>
     </template>
   </dialog-base>

--- a/app/imports/client/ui/creature/character/CharacterDeleteDialog.vue
+++ b/app/imports/client/ui/creature/character/CharacterDeleteDialog.vue
@@ -1,11 +1,11 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Delete Character
+      {{ $t('creature.character.characterDeleteDialog.title') }}
     </v-toolbar-title>
     <div>
       <p v-if="name">
-        Type "{{ name }}" to permanently delete the character
+        {{ $t('creature.character.characterDeleteDialog.typeToDelete') }} "{{ name }}" {{ $t('creature.character.characterDeleteDialog.toPermanentlyDelete') }}
       </p>
       <v-text-field
         v-if="name"
@@ -16,7 +16,7 @@
         class="primary"
         @click="remove"
       >
-        Delete forever
+        {{ $t('creature.character.characterDeleteDialog.deleteForever') }}
       </v-btn>
     </div>
     <v-spacer slot="actions" />
@@ -25,7 +25,7 @@
       text
       @click="$store.dispatch('popDialogStack')"
     >
-      Cancel
+      {{ $t('creature.character.characterDeleteDialog.cancel') }}
     </v-btn>
   </dialog-base>
 </template>

--- a/app/imports/client/ui/creature/character/CharacterImportDialog.vue
+++ b/app/imports/client/ui/creature/character/CharacterImportDialog.vue
@@ -1,14 +1,14 @@
 <template>
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Import character 
+      {{ $t('creature.character.characterImportDialog.title') }}
     </v-toolbar-title>
     <div>
       <h2 class="mb-4">
-        Import a character from another instance of DiceCloud
+        {{ $t('creature.character.characterImportDialog.importCharacter') }}
       </h2>
       <p>
-        The character needs to have their sharing permission set to "anyone can view"
+        {{ $t('creature.character.characterImportDialog.importCharacterDescription') }}
       </p>
       <text-field
         :value="currentUrl"
@@ -23,7 +23,7 @@
             color="primary"
             @click="importCharacterData"
           >
-            Import
+            {{ $t('creature.character.characterImportDialog.import') }}
           </v-btn>
         </v-slide-x-transition>
       </div>
@@ -33,7 +33,7 @@
         text
         @click="$emit('pop')"
       >
-        Cancel
+        {{ $t('creature.character.characterImportDialog.cancel') }}
       </v-btn>
     </template>
   </dialog-base>
@@ -82,8 +82,8 @@ export default {
         return;
       }
       if (characterData.error) {
-        if (characterData.reason === 'No user ID. Are you logged in?') {
-          ack('This character\'s sharing settings are not set to allow anyone to view')
+        if (characterData.reason === this.$t('creature.character.characterImportDialog.errors.noUserId')) {
+          ack(this.$t('creature.character.characterImportDialog.errors.ackNoUserId'))
         } else {
           ack(characterData.reason ?? characterData.error);
         }

--- a/app/imports/client/ui/creature/character/CharacterSheet.vue
+++ b/app/imports/client/ui/creature/character/CharacterSheet.vue
@@ -8,11 +8,10 @@
           justify-center
         >
           <h2 style="margin: 48px 28px 16px">
-            Character not found
+            {{ $t('creature.character.characterSheet.notFound') }}
           </h2>
           <h3>
-            Either this character does not exist, or you don't have permission
-            to view it.
+            {{ $t('creature.character.characterSheet.notFoundDescription') }}
           </h3>
         </v-layout>
       </div>
@@ -81,35 +80,35 @@
       )"
     >
       <v-btn>
-        <span>Stats</span>
+        <span>{{ $t('creature.character.characterSheet.stats') }}</span>
         <v-icon>mdi-chart-box</v-icon>
       </v-btn>
       <v-btn>
-        <span>Actions</span>
+        <span>{{ $t('creature.character.characterSheet.actions') }}</span>
         <v-icon>mdi-lightning-bolt</v-icon>
       </v-btn>
       <v-btn v-if="!creature.settings.hideSpellsTab">
-        <span>Spells</span>
+        <span>{{ $t('creature.character.characterSheet.spells') }}</span>
         <v-icon>mdi-fire</v-icon>
       </v-btn>
       <v-btn>
-        <span>Inventory</span>
+        <span>{{ $t('creature.character.characterSheet.inventory') }}</span>
         <v-icon>mdi-cube</v-icon>
       </v-btn>
       <v-btn>
-        <span>Features</span>
+        <span>{{ $t('creature.character.characterSheet.features') }}</span>
         <v-icon>mdi-text</v-icon>
       </v-btn>
       <v-btn>
-        <span>Journal</span>
+        <span>{{ $t('creature.character.characterSheet.journal') }}</span>
         <v-icon>mdi-book-open-variant</v-icon>
       </v-btn>
       <v-btn>
-        <span>Build</span>
+        <span>{{ $t('creature.character.characterSheet.build') }}</span>
         <v-icon>mdi-wrench</v-icon>
       </v-btn>
       <v-btn v-if="creature.settings.showTreeTab">
-        <span>Tree</span>
+        <span>{{ $t('creature.character.characterSheet.tree') }}</span>
         <v-icon>mdi-file-tree</v-icon>
       </v-btn>
     </v-bottom-navigation>
@@ -169,20 +168,20 @@ export default {
   },
   watch: {
     'creature.name'(value) {
-      this.$store.commit('setPageTitle', value || 'Character Sheet');
+      this.$store.commit('setPageTitle', value || this.$t('creature.character.characterSheet.characterSheet'));
     },
   },
   mounted() {
-    this.$store.commit('setPageTitle', this.creature && this.creature.name || 'Character Sheet');
+    this.$store.commit('setPageTitle', this.creature && this.creature.name || this.$t('creature.character.characterSheet.characterSheet'));
     this.nameObserver = Creatures.find({
       creatureId: this.creatureId,
     }, {
       fields: { name: 1 },
     }).observe({
       added: ({ name }) =>
-        this.$store.commit('setPageTitle', name || 'Character Sheet'),
+        this.$store.commit('setPageTitle', name || this.$t('creature.character.characterSheet.characterSheet')),
       changed: ({ name }) =>
-        this.$store.commit('setPageTitle', name || 'Character Sheet'),
+        this.$store.commit('setPageTitle', name || this.$t('creature.character.characterSheet.characterSheet')),
     });
     if (this.$route.name === 'characterSheet') {
       let that = this;

--- a/app/imports/client/ui/creature/character/CharacterSheetToolbar.vue
+++ b/app/imports/client/ui/creature/character/CharacterSheetToolbar.vue
@@ -55,7 +55,7 @@
                     {{ ownerName }}
                   </v-list-item-title>
                   <v-list-item-subtitle>
-                    Sheet owner
+                    {{ $t('creature.character.characterSheetToolbar.sheetOwner') }}
                   </v-list-item-subtitle>
                 </v-list-item-content>
               </v-list-item>
@@ -66,21 +66,21 @@
                 <v-list-item-title>
                   <v-icon left>
                     mdi-cancel
-                  </v-icon> Unshare with me
+                  </v-icon> {{ $t('creature.character.characterSheetToolbar.unshareWithMe') }}
                 </v-list-item-title>
               </v-list-item>
               <v-list-item :to="printUrl">
                 <v-list-item-title>
                   <v-icon left>
                     mdi-printer
-                  </v-icon> Print
+                  </v-icon> {{ $t('creature.character.characterSheetToolbar.print') }}
                 </v-list-item-title>
               </v-list-item>
               <v-list-item @click="showCharacterForm">
                 <v-list-item-title>
                   <v-icon left>
                     mdi-pencil
-                  </v-icon> Edit details
+                  </v-icon> {{ $t('creature.character.characterSheetToolbar.editDetails') }}
                 </v-list-item-title>
               </v-list-item>
               <v-list-item
@@ -90,7 +90,7 @@
                 <v-list-item-title>
                   <v-icon left>
                     mdi-share-variant
-                  </v-icon> Sharing
+                  </v-icon> {{ $t('creature.character.characterSheetToolbar.share') }}
                 </v-list-item-title>
               </v-list-item>
               <v-list-item
@@ -100,7 +100,7 @@
                 <v-list-item-title>
                   <v-icon left>
                     mdi-delete
-                  </v-icon> Delete
+                  </v-icon> {{ $t('creature.character.characterSheetToolbar.delete') }}
                 </v-list-item-title>
               </v-list-item>
             </v-list>
@@ -140,28 +140,28 @@
           )"
         >
           <v-tab>
-            Stats
+            {{ $t('creature.character.characterSheetToolbar.tab.stats') }}
           </v-tab>
           <v-tab>
-            Actions
+            {{ $t('creature.character.characterSheetToolbar.tab.actions') }}
           </v-tab>
           <v-tab v-if="!creature.settings.hideSpellsTab">
-            Spells
+            {{ $t('creature.character.characterSheetToolbar.tab.spells') }}
           </v-tab>
           <v-tab>
-            Inventory
+            {{ $t('creature.character.characterSheetToolbar.tab.inventory') }}
           </v-tab>
           <v-tab>
-            Features
+            {{ $t('creature.character.characterSheetToolbar.tab.features') }}
           </v-tab>
           <v-tab>
-            Journal
+            {{ $t('creature.character.characterSheetToolbar.tab.journal') }}
           </v-tab>
           <v-tab>
-            Build
+            {{ $t('creature.character.characterSheetToolbar.tab.build') }}
           </v-tab>
           <v-tab v-if="creature.settings.showTreeTab">
-            Tree
+            {{ $t('creature.character.characterSheetToolbar.tab.tree') }}
           </v-tab>
         </v-tabs>
         <v-spacer />

--- a/app/imports/client/ui/creature/character/CreatureRootDialog.vue
+++ b/app/imports/client/ui/creature/character/CreatureRootDialog.vue
@@ -56,7 +56,7 @@
         color="accent"
         @click="$store.dispatch('popDialogStack')"
       >
-        Close
+        {{ $t('creature.character.creatureRootDialog.close') }}
       </v-btn>
     </div>
   </dialog-base>

--- a/app/imports/client/ui/creature/character/MiniCharacterSheet.vue
+++ b/app/imports/client/ui/creature/character/MiniCharacterSheet.vue
@@ -3,7 +3,7 @@
     hover
     @click="$emit('click')"
   >
-    Character sheet
+    {{ $t('creature.character.miniCharacterSheet.characterSheet') }}
   </v-card>
 </template>
 

--- a/app/imports/client/ui/creature/character/characterSheetTabs/BuildTab.vue
+++ b/app/imports/client/ui/creature/character/characterSheetTabs/BuildTab.vue
@@ -29,7 +29,7 @@
       >
         <v-card class="pb-4">
           <v-card-title style="height: 68px;">
-            Slots
+            {{ $t('creature.character.characterSheetTabs.buildTab.slots') }}
             <v-spacer />
             <v-scale-transition>
               <v-menu
@@ -59,7 +59,7 @@
                     <v-icon class="mr-2">
                       mdi-file-hidden
                     </v-icon>
-                    {{ hiddenCount }} hidden {{ hiddenCount > 1 ? 'properties' : 'property' }}
+                    {{ hiddenCount }} {{ $t('creature.character.characterSheetTabs.buildTab.hidden') }} {{ hiddenCount > 1 ? 'properties' : 'property' }}
                   </v-subheader>
                   <v-list-item
                     v-for="pointBuy in hiddenPointBuys"
@@ -98,7 +98,7 @@
             v-if="variables.level"
             class="text-h6"
           >
-            Level {{ variables.level.value }}
+            {{ $t('creature.character.characterSheetTabs.buildTab.level') }} {{ variables.level.value }}
           </v-card-title>
           <v-list two-line>
             <v-list-item>
@@ -109,7 +109,7 @@
                       variables.milestoneLevels.value
                   "
                 >
-                  {{ variables.milestoneLevels.value }} Milestone levels
+                  {{ variables.milestoneLevels.value }} {{ $t('creature.character.characterSheetTabs.buildTab.milestoneLevels') }}
                 </v-list-item-title>
                 <v-list-item-title
                   v-if="
@@ -171,10 +171,10 @@
                     mdi-plus
                   </v-icon>
                   <template v-if="cls.missingLevels && cls.missingLevels.length">
-                    Get Missing Levels 
+                    {{ $t('creature.character.characterSheetTabs.buildTab.gettingMissingLevels') }}
                   </template>
                   <template v-else>
-                    Level Up
+                    {{ $t('creature.character.characterSheetTabs.buildTab.levelUp') }}
                   </template> 
                 </v-btn>
               </v-list-item-action>

--- a/app/imports/client/ui/creature/character/characterSheetTabs/InventoryTab.vue
+++ b/app/imports/client/ui/creature/character/characterSheetTabs/InventoryTab.vue
@@ -18,7 +18,7 @@
               </v-list-item-avatar>
               <v-list-item-content>
                 <v-list-item-title>
-                  Weight Carried
+                  {{ $t('creature.character.characterSheetTabs.inventoryTab.weightCarried') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -33,7 +33,7 @@
               </v-list-item-avatar>
               <v-list-item-content>
                 <v-list-item-title>
-                  Net worth
+                  {{ $t('creature.character.characterSheetTabs.inventoryTab.netWorth') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -48,7 +48,7 @@
               </v-list-item-avatar>
               <v-list-item-content>
                 <v-list-item-title>
-                  Items attuned
+                  {{ $t('creature.character.characterSheetTabs.inventoryTab.itemsAttuned') }}
                 </v-list-item-title>
               </v-list-item-content>
               <v-list-item-action>
@@ -63,7 +63,7 @@
       <div>
         <toolbar-card transparent-toolbar>
           <v-toolbar-title slot="toolbar">
-            Equipped
+            {{ $t('creature.character.characterSheetTabs.inventoryTab.equipped') }}
           </v-toolbar-title>
           <v-card-text class="px-0">
             <item-list
@@ -77,7 +77,7 @@
       <div>
         <toolbar-card transparent-toolbar>
           <v-toolbar-title slot="toolbar">
-            Carried
+            {{ $t('creature.character.characterSheetTabs.inventoryTab.carried') }}
           </v-toolbar-title>
           <v-card-text class="px-0">
             <item-list

--- a/app/imports/client/ui/creature/character/characterSheetTabs/StatsTab.vue
+++ b/app/imports/client/ui/creature/character/characterSheetTabs/StatsTab.vue
@@ -76,7 +76,7 @@
       >
         <v-card>
           <v-list>
-            <v-subheader>Buffs and conditions</v-subheader>
+            <v-subheader>{{ $t('creature.character.characterSheetTabs.statsTab.buffsAndConditions') }}</v-subheader>
             <buff-list-item
               v-for="buff in properties.buff"
               :key="buff._id"
@@ -166,7 +166,7 @@
       >
         <v-card>
           <v-list>
-            <v-subheader>Hit Dice</v-subheader>
+            <v-subheader>{{ $t('creature.character.characterSheetTabs.statsTab.hitDice') }}</v-subheader>
             <template v-for="(hitDie, index) in properties.attribute.hitDice">
               <v-divider
                 v-if="index !== 0"
@@ -222,7 +222,7 @@
       >
         <v-card>
           <v-list>
-            <v-subheader>Saving Throws</v-subheader>
+            <v-subheader>{{ $t('creature.character.characterSheetTabs.statsTab.savingThrows') }}</v-subheader>
             <skill-list-tile
               v-for="save in properties.skill.save"
               :key="save._id"
@@ -253,7 +253,7 @@
       >
         <v-card>
           <v-list>
-            <v-subheader>Skills</v-subheader>
+            <v-subheader>{{ $t('creature.character.characterSheetTabs.statsTab.skills') }}</v-subheader>
             <skill-list-tile
               v-for="skill in properties.skill.skill"
               :key="skill._id"
@@ -294,7 +294,7 @@
         <v-card>
           <v-list>
             <v-subheader>
-              Weapons
+              {{ $t('creature.character.characterSheetTabs.statsTab.weapons') }}
             </v-subheader>
             <skill-list-tile
               v-for="weapon in properties.skill.weapon"
@@ -314,7 +314,7 @@
         <v-card>
           <v-list>
             <v-subheader>
-              Armor
+              {{ $t('creature.character.characterSheetTabs.statsTab.armor') }}
             </v-subheader>
             <skill-list-tile
               v-for="armor in properties.skill.armor"
@@ -334,7 +334,7 @@
         <v-card>
           <v-list>
             <v-subheader>
-              Tools
+              {{ $t('creature.character.characterSheetTabs.statsTab.tools') }}
             </v-subheader>
             <skill-list-tile
               v-for="tool in properties.skill.tool"
@@ -354,7 +354,7 @@
         <v-card>
           <v-list>
             <v-subheader>
-              Languages
+              {{ $t('creature.character.characterSheetTabs.statsTab.languages') }}
             </v-subheader>
             <skill-list-tile
               v-for="language in properties.skill.language"

--- a/app/imports/client/ui/creature/character/errors/DependencyLoopError.vue
+++ b/app/imports/client/ui/creature/character/errors/DependencyLoopError.vue
@@ -7,10 +7,10 @@
     class="dependency-loop-error"
   >
     <p>
-      The character contains a dependency loop.
+      {{ $t('creature.character.errors.dependencyLoopError.theCharacterContains') }}
     </p>
     <p>
-      A set of properties may have been calculated incorrectly, because they form an infinite loop:
+      {{ $t('creature.character.errors.dependencyLoopError.aSetOfPropertiesMayHaveBeenCalculatedIncorrectly') }}
     </p>
     <div class="d-flex align-center flex-wrap">
       <template

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/CharacterSheetPrinted.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/CharacterSheetPrinted.vue
@@ -19,11 +19,10 @@
           justify-center
         >
           <h2 style="margin: 48px 28px 16px">
-            Character not found
+            {{ $t('creature.character.printedCharacterSheet.notFound') }}
           </h2>
           <h3>
-            Either this character does not exist, or you don't have permission
-            to view it.
+            {{ $t('creature.character.printedCharacterSheet.notFoundDescription') }}
           </h3>
         </v-layout>
       </div>
@@ -48,10 +47,10 @@
                 {{ creature.gender }} {{ race }}
               </dir>
               <div v-if="level && classes && classes.length === 1">
-                Level {{ level }} {{ classes[0].name }}
+                {{ $t('creature.character.printedCharacterSheet.level') }} {{ level }} {{ classes[0].name }}
               </div>
               <div v-else-if="level">
-                Level {{ level }} ({{ classes.map(c => `${c.name} ${c.level}`).join(', ') }})
+                {{ $t('creature.character.printedCharacterSheet.level') }} {{ level }} ({{ classes.map(c => `${c.name} ${c.level}`).join(', ') }})
               </div>
             </div>
             <qrcode-vue
@@ -145,14 +144,14 @@ export default {
   },
   watch: {
     'creature.name'(value) {
-      this.$store.commit('setPageTitle', value ? ('Print ' + value) : 'Print Character Sheet');
+      this.$store.commit('setPageTitle', value ? (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + value) : (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + this.$t('creature.character.characterSheet.characterSheet')));
     },
   },
   mounted() {
     this.$store.commit('setPageTitle',
       (this.creature && this.creature.name) ?
-        ('Print ' + this.creature.name) :
-        'Print Character Sheet'
+        (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + this.creature.name) :
+        (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + this.$t('creature.character.characterSheet.characterSheet'))
     );
     this.nameObserver = Creatures.find({
       creatureId: this.creatureId,
@@ -160,9 +159,9 @@ export default {
       fields: { name: 1 },
     }).observe({
       added: ({ name }) =>
-        this.$store.commit('setPageTitle', name ? ('Print ' + name) : 'Print Character Sheet'),
+        this.$store.commit('setPageTitle', name ? (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + name) : (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + this.$t('creature.character.characterSheet.characterSheet'))),
       changed: ({ name }) =>
-        this.$store.commit('setPageTitle', name ? ('Print ' + name) : 'Print Character Sheet'),
+        this.$store.commit('setPageTitle', name ? (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + name) : (this.$t('creature.character.printedCharacterSheet.printPrefix') + ' ' + this.$t('creature.character.characterSheet.characterSheet'))),
     });
   },
   beforeDestroy() {

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/PrintedInventory.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/PrintedInventory.vue
@@ -4,16 +4,16 @@
   >
     <div class="double-border my-2">
       <div class="label text-center">
-        Inventory
+        {{ $t('creature.character.printedCharacterSheet.inventory.title') }}
       </div>
       <div class="d-flex inventory-stat">
         <v-icon>$vuetify.icons.injustice</v-icon>
-        Weight Carried:
-        {{ weightCarried }} lb
+        {{ $t('creature.character.printedCharacterSheet.inventory.weightCarried') }}:
+        {{ weightCarried }} {{ $t('creature.character.printedCharacterSheet.inventory.lb') }}
       </div>
       <div class="d-flex inventory-stat">
         <v-icon>$vuetify.icons.cash</v-icon>
-        Net worth:
+        {{ $t('creature.character.printedCharacterSheet.inventory.netWorth') }}:
         <coin-value
           class="ml-2"
           :value="variables && variables.valueTotal && variables.valueTotal.value|| 0"
@@ -24,13 +24,13 @@
         class="d-flex inventory-stat"
       >
         <v-icon>$vuetify.icons.spell</v-icon>
-        Items attuned:
+        {{ $t('creature.character.printedCharacterSheet.inventory.itemsAttuned') }}:
         {{ variables.itemsAttuned && variables.itemsAttuned.value }}
       </div>
     </div>
     <div class="double-border my-2">
       <div class="label text-center">
-        Equipped
+        {{ $t('creature.character.printedCharacterSheet.inventory.equipped') }}
       </div>
       <column-layout wide-columns>
         <printed-item
@@ -42,7 +42,7 @@
     </div>
     <div class="double-border my-2">
       <div class="label text-center">
-        Carried
+        {{ $t('creature.character.printedCharacterSheet.inventory.carried') }}
       </div>
       <column-layout wide-columns>
         <printed-item

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/PrintedSpells.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/PrintedSpells.vue
@@ -5,7 +5,7 @@
     <div
       class="label text-center octagon-border my-2 avoid-page-break-after"
     >
-      Spells
+      {{ $t('creature.character.printedCharacterSheet.spells.title') }}
     </div>
     <column-layout
       v-if="spellsWithoutList && spellsWithoutList.length"

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/PrintedStats.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/PrintedStats.vue
@@ -113,7 +113,7 @@
         <div class="double-border">
           <div>
             <b>
-              Total:
+              {{ $t('creature.character.printedCharacterSheet.stats.total') }}:
             </b>
             <span>
               {{ healthBar.total }}
@@ -140,7 +140,7 @@
         <div class="double-border">
           <div>
             <b>
-              Total:
+              {{ $t('creature.character.printedCharacterSheet.stats.total') }}:
             </b>
             <span
               v-for="hitDie in hitDice"
@@ -155,7 +155,7 @@
             style="text-align: center;"
             class="label"
           >
-            Hit Dice
+            {{ $t('creature.character.printedCharacterSheet.stats.hitDice') }}
           </div>
         </div>
       </div>
@@ -177,7 +177,7 @@
           <div
             v-if="resource.total > 8"
           >
-            total: {{ resource.total }}
+            {{ $t('creature.character.printedCharacterSheet.stats.total') }}: {{ resource.total }}
             <div style="height: 60px;" />
           </div>
           <div
@@ -220,7 +220,7 @@
             * {{ effect.text }}
           </div>
           <div class="label text-center">
-            Saving Throws
+            {{ $t('creature.character.printedCharacterSheet.stats.savingThrows') }}
           </div>
         </div>
       </div>
@@ -245,7 +245,7 @@
             * {{ effect.text }}
           </div>
           <div class="label text-center">
-            Skills
+            {{ $t('creature.character.printedCharacterSheet.stats.skills') }}
           </div>
         </div>
       </div>
@@ -254,19 +254,19 @@
           class="double-border"
         >
           <p>
-            <b>Weapons:</b> {{ weapons.map(p => p.name).join(', ') }}
+            <b>{{ $t('creature.character.printedCharacterSheet.stats.weapons') }}:</b> {{ weapons.map(p => p.name).join(', ') }}
           </p>
           <p>
-            <b>Armor:</b> {{ armors.map(p => p.name).join(', ') }}
+            <b>{{ $t('creature.character.printedCharacterSheet.stats.armor') }}:</b> {{ armors.map(p => p.name).join(', ') }}
           </p>
           <p>
-            <b>Tools:</b> {{ tools.map(p => p.name).join(', ') }}
+            <b>{{ $t('creature.character.printedCharacterSheet.stats.tools') }}:</b> {{ tools.map(p => p.name).join(', ') }}
           </p>
           <p>
-            <b>Languages:</b> {{ languages.map(p => p.name).join(', ') }}
+            <b>{{ $t('creature.character.printedCharacterSheet.stats.languages') }}:</b> {{ languages.map(p => p.name).join(', ') }}
           </p>
           <div class="label text-center">
-            Proficiencies
+            {{ $t('creature.character.printedCharacterSheet.stats.proficiencies') }}
           </div>
         </div>
       </div>
@@ -276,7 +276,7 @@
       >
         <div class="double-border">
           <div class="label text-center">
-            Spell Slots
+            {{ $t('creature.character.printedCharacterSheet.stats.spellSlots') }}
           </div>
           <div
             v-for="spellSlot in spellSlots"
@@ -290,7 +290,7 @@
             <div
               v-if="spellSlot.total > 8"
             >
-              Total: {{ spellSlot.total }}
+              {{ $t('creature.character.printedCharacterSheet.stats.total') }}: {{ spellSlot.total }}
             </div>
             <div
               v-else

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedAction.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedAction.vue
@@ -18,7 +18,7 @@
       v-if="Number.isFinite(model.uses)"
       class="action-sub-title d-flex align-center"
     >
-      {{ model.uses }} uses
+      {{ model.uses }} {{ $t('creature.character.printedCharacterSheet.actions.uses') }}
     </div>
     <div>
       <div
@@ -31,14 +31,14 @@
           :key="attributeConsumed._id"
           class="layout align-center justify-start"
         >
-          Cost: {{ attributeConsumed.quantity && attributeConsumed.quantity.value }} {{ attributeConsumed.statName || attributeConsumed.variableName }}
+          {{ $t('creature.character.printedCharacterSheet.actions.cost') }}: {{ attributeConsumed.quantity && attributeConsumed.quantity.value }} {{ attributeConsumed.statName || attributeConsumed.variableName }}
         </div>
         <div
           v-for="itemConsumed in model.resources.itemsConsumed"
           :key="itemConsumed._id"
         >
           <template v-if="itemConsumed.itemName">
-            Uses: {{ itemConsumed.quantity && itemConsumed.quantity.value || 0 }} {{ itemConsumed.itemName || itemConsumed.tag }}
+            {{ $t('creature.character.printedCharacterSheet.actions.usesCap') }}: {{ itemConsumed.quantity && itemConsumed.quantity.value || 0 }} {{ itemConsumed.itemName || itemConsumed.tag }}
           </template>
         </div>
       </div>
@@ -53,7 +53,7 @@
           {{ rollBonus }}
         </span>
         <span>
-          to hit
+          {{ $t('creature.character.printedCharacterSheet.actions.toHit') }}
         </span>
       </div>
       <tree-node-list
@@ -131,12 +131,12 @@ export default {
     },
     actionTypeName() {
       return {
-        'action': 'Action',
-        'bonus': 'Bonus Action',
-        'attack': 'Attack',
-        'reaction': 'Reaction',
-        'free': 'Free Action',
-        'long': 'Long Action'
+        'action': this.$t('creature.character.printedCharacterSheet.actions.types.action'),
+        'bonus': this.$t('creature.character.printedCharacterSheet.actions.types.bonus'),
+        'attack': this.$t('creature.character.printedCharacterSheet.actions.types.attack'),
+        'reaction': this.$t('creature.character.printedCharacterSheet.actions.types.reaction'),
+        'free': this.$t('creature.character.printedCharacterSheet.actions.types.free'),
+        'long': this.$t('creature.character.printedCharacterSheet.actions.types.long')
       }[this.model.actionType] || this.model.actionType
     },
   },

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedBlockItem.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedBlockItem.vue
@@ -52,7 +52,7 @@
               v-if="model.quantity > 1"
               class="ml-1"
             >
-              each
+              {{ $t('creature.character.printedCharacterSheet.inventory.each') }}
             </span>
           </v-layout>
         </div>
@@ -73,7 +73,7 @@
             >
               $vuetify.icons.injustice
             </v-icon>
-            {{ totalWeight }} lb
+            {{ totalWeight }} {{ $t('creature.character.printedCharacterSheet.inventory.lb') }}
           </v-layout>
           <v-layout align-center>
             <v-icon
@@ -82,12 +82,12 @@
             >
               $vuetify.icons.weight
             </v-icon>
-            {{ model.weight }} lb
+            {{ model.weight }} {{ $t('creature.character.printedCharacterSheet.inventory.lb') }}
             <span
               v-if="model.quantity > 1"
               class="ml-1"
             >
-              each
+              {{ $t('creature.character.printedCharacterSheet.inventory.each') }}
             </span>
           </v-layout>
         </div>
@@ -152,8 +152,8 @@ export default {
     },
     attunementText() {
       if (this.model.requiresAttunement) {
-        if (this.model.attuned) return 'Attuned';
-        return 'Requires attunement';
+        if (this.model.attuned) return this.$t('creature.character.printedCharacterSheet.inventory.attuned');
+        return this.$t('creature.character.printedCharacterSheet.inventory.requiresAttunement');
       }
       return undefined;
     }

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedContainer.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedContainer.vue
@@ -48,7 +48,7 @@
             <span
               class="ml-1"
             >
-              contents
+              {{ $t('creature.character.printedCharacterSheet.inventory.contents') }}
             </span>
           </v-layout>
         </div>
@@ -65,7 +65,7 @@
             >
               $vuetify.icons.weight
             </v-icon>
-            {{ model.weight }} lb
+            {{ model.weight }} {{ $t('creature.character.printedCharacterSheet.inventory.lb') }}
           </v-layout>
 
           <v-layout
@@ -78,11 +78,11 @@
             >
               $vuetify.icons.injustice
             </v-icon>
-            {{ model.contentsWeight }} lb
+            {{ model.contentsWeight }} {{ $t('creature.character.printedCharacterSheet.inventory.lb') }}
             <span
               class="ml-1"
             >
-              contents
+              {{ $t('creature.character.printedCharacterSheet.inventory.contents') }}
             </span>
           </v-layout>
         </div>

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedLineItem.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedLineItem.vue
@@ -41,7 +41,7 @@
           <template
             v-if="model.weight"
           >
-            {{ totalWeight }} lb
+            {{ totalWeight }} {{ $t('creature.character.printedCharacterSheet.inventory.lb') }}
           </template>
         </div>
       </div>
@@ -88,8 +88,8 @@ export default {
     },
     attunementText() {
       if (this.model.requiresAttunement) {
-        if (this.model.attuned) return 'Attuned';
-        return 'Requires attunement';
+        if (this.model.attuned) return this.$t('creature.character.printedCharacterSheet.inventory.attuned');
+        return this.$t('creature.character.printedCharacterSheet.inventory.requiresAttunement');
       }
       return undefined;
     }

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedSpell.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedSpell.vue
@@ -22,27 +22,27 @@
       </div>
     </div>
     <div v-if="model.level">
-      {{ levelText }} {{ model.school }} {{ model.ritual ? '(ritual)' : '' }}
+      {{ levelText }} {{ model.school }} {{ model.ritual ? $t('creature.character.printedCharacterSheet.spell.ritual') : '' }}
     </div>
     <div v-else>
-      {{ model.school }} cantrip {{ model.ritual ? '(ritual)' : '' }}
+      {{ model.school }} {{ $t('creature.character.printedCharacterSheet.spell.level.cantrip') }} {{ model.ritual ? $t('creature.character.printedCharacterSheet.spell.ritual') : '' }}
     </div>
     <div
       v-if="rollBonus"
     >
-      <b>To hit:</b> {{ rollBonus }}
+      <b>{{ $t('creature.character.printedCharacterSheet.spell.toHit') }}:</b> {{ rollBonus }}
     </div>
     <div>
-      <b>Casting time:</b> {{ model.castingTime }}
+      <b>{{ $t('creature.character.printedCharacterSheet.spell.castingTime') }}:</b> {{ model.castingTime }}
     </div>
     <div>
-      <b>Range:</b> {{ model.range }}
+      <b>{{ $t('creature.character.printedCharacterSheet.spell.range') }}:</b> {{ model.range }}
     </div>
     <div>
-      <b>Components:</b> {{ spellComponents }}
+      <b>{{ $t('creature.character.printedCharacterSheet.spell.components') }}:</b> {{ spellComponents }}
     </div>
     <div class="mb-4">
-      <b>Duration:</b> {{ model.duration }}
+      <b>{{ $t('creature.character.printedCharacterSheet.spell.duration') }}:</b> {{ model.duration }}
     </div>
     <property-description
       text
@@ -61,10 +61,7 @@ import PropertyDescription from '/imports/client/ui/properties/viewers/shared/Pr
 import numberToSignedString from '/imports/api/utility/numberToSignedString';
 import romanize from '/imports/client/ui/utility/romanize';
 
-const levelText = [
-  'cantrip', '1st-level', '2nd-level', '3rd-level', '4th-level', '5th-level',
-  '6th-level', '7th-level', '8th-level', '9th-level'
-];
+
 
 export default {
   components: {
@@ -79,7 +76,10 @@ export default {
   },
   computed: {
     levelText() {
-      return levelText[this.model.level] || `level ${this.model.level}`;
+      // return levelText[this.model.level] || `level ${this.model.level}`;
+      const lvl = this.model.level;
+      if (lvl >= 1 && lvl <= 9) return this.$t(`creature.character.printedCharacterSheet.spell.level.${lvl}`);
+      return this.$t('creature.character.printedCharacterSheet.spell.level.generic', { level: lvl });
     },
     romanLevel() {
       return romanize(this.model.level) || this.model.level;

--- a/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedSpellList.vue
+++ b/app/imports/client/ui/creature/character/printedCharacterSheet/components/PrintedSpellList.vue
@@ -7,19 +7,19 @@
       {{ model.name }}
     </div>
     <div>
-      Spell Save DC: {{ model.dc && model.dc.value }}
+      {{ $t('creature.character.printedCharacterSheet.spellList.saveDc') }}: {{ model.dc && model.dc.value }}
     </div>
     <div v-if="model.ability">
-      Spell casting ability: {{ model.ability }}
+      {{ $t('creature.character.printedCharacterSheet.spellList.ability') }}: {{ model.ability }}
     </div>
     <div v-if="model.ability">
-      Spell casting ability modifier: {{ model.abilityMod }}
+      {{ $t('creature.character.printedCharacterSheet.spellList.abilityMod') }}: {{ model.abilityMod }}
     </div>
     <div>
-      Spell Attack Bonus: {{ model.attackRollBonus && model.attackRollBonus.value }}
+      {{ $t('creature.character.printedCharacterSheet.spellList.attackBonus') }}: {{ model.attackRollBonus && model.attackRollBonus.value }}
     </div>
     <div>
-      Maximum prepared spells: {{ model.maxPrepared && model.maxPrepared.value }}
+      {{ $t('creature.character.printedCharacterSheet.spellList.maxPrepared') }}: {{ model.maxPrepared && model.maxPrepared.value }}
     </div>
     <property-description
       text

--- a/app/imports/client/ui/creature/creatureList/ArchiveButton.vue
+++ b/app/imports/client/ui/creature/creatureList/ArchiveButton.vue
@@ -7,7 +7,7 @@
     @click="openArchive"
   >
     <template v-if="text">
-      Archive Characters
+      {{ $t('creature.creatureList.archiveButton') }}
     </template>
     <v-icon :right="text">
       mdi-archive

--- a/app/imports/client/ui/creature/creatureProperties/CreaturePropertyDialog.vue
+++ b/app/imports/client/ui/creature/creatureProperties/CreaturePropertyDialog.vue
@@ -65,7 +65,7 @@
           color="accent"
           @click="$store.dispatch('popDialogStack')"
         >
-          Close
+          {{ $t('creature.creatureProperties.creaturePropertyDialog.close') }}
         </v-btn>
       </div>
     </template>

--- a/app/imports/client/ui/creature/creatureProperties/CreaturePropertyFromLibraryDialog.vue
+++ b/app/imports/client/ui/creature/creatureProperties/CreaturePropertyFromLibraryDialog.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Add from library
+      {{ $t('creature.creatureProperties.creaturePropertyFromLibraryDialog.addFromLibrary') }}
     </v-toolbar-title>
     <library-and-node
       slot="unwrapped-content"
@@ -16,7 +16,7 @@
         color="primary"
         @click="$store.dispatch('popDialogStack', node)"
       >
-        Insert
+        {{ $t('creature.creatureProperties.creaturePropertyFromLibraryDialog.insert') }}
       </v-btn>
     </template>
   </dialog-base>

--- a/app/imports/client/ui/creature/dependencyGraph/DependencyGraphDialog.vue
+++ b/app/imports/client/ui/creature/dependencyGraph/DependencyGraphDialog.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <dialog-base class="dependency-graph">
     <div slot="toolbar">
-      Dependency Graph
+      {{ $t('creature.dependencyGraph.dependencyGraphDialog.title') }}
     </div>
     <div
       id="dependency-graph-container"

--- a/app/imports/client/ui/creature/experiences/ExperienceForm.vue
+++ b/app/imports/client/ui/creature/experiences/ExperienceForm.vue
@@ -2,14 +2,14 @@
   <div class="experience-form">
     <div class="layout column align-center">
       <smart-switch
-        label="Milestone"
+        :label="$t('creature.experiences.experienceForm.switch.milestone')"
         class="mx-3"
         :value="milestone"
         @change="makeMilestone"
       />
       <text-field
         v-if="milestone"
-        label="Levels"
+        :label="$t('creature.experiences.experienceForm.fields.levels')"
         type="number"
         class="base-value-field text-center large-format no-flex"
         :value="model.levels"
@@ -28,7 +28,7 @@
       />
     </div>
     <text-field
-      label="Name"
+      :label="$t('creature.experiences.experienceForm.fields.name')"
       :autofocus="milestone"
       :value="model.name"
       :error-messages="errors.name"

--- a/app/imports/client/ui/creature/experiences/ExperienceInsertDialog.vue
+++ b/app/imports/client/ui/creature/experiences/ExperienceInsertDialog.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Add Experience
+      {{ $t('creature.experiences.experienceInsertDialog.addExperience') }}
     </v-toolbar-title>
     <experience-form
       :start-as-milestone="startAsMilestone"
@@ -20,7 +20,7 @@
         :disabled="!valid"
         @click="insertExperience"
       >
-        Insert
+        {{ $t('creature.experiences.experienceInsertDialog.insert') }}
       </v-btn>
     </div>
   </dialog-base>

--- a/app/imports/client/ui/creature/experiences/ExperienceListDialog.vue
+++ b/app/imports/client/ui/creature/experiences/ExperienceListDialog.vue
@@ -2,7 +2,7 @@
   <dialog-base>
     <template slot="toolbar">
       <v-toolbar-title>
-        Experiences
+        {{ $t('creature.experiences.experienceListDialog.title') }}
       </v-toolbar-title>
       <v-spacer />
       <v-btn
@@ -36,7 +36,7 @@
         $vuetify.icons.baby_face
       </v-icon>
       <p class="text-h5">
-        No experiences
+        {{ $t('creature.experiences.experienceListDialog.noExperiences') }}
       </p>
     </div>
     <v-list v-else>

--- a/app/imports/client/ui/creature/slots/LevelUpDialog.vue
+++ b/app/imports/client/ui/creature/slots/LevelUpDialog.vue
@@ -129,7 +129,7 @@
         outlined
         @click="loadMore"
       >
-        Load More
+        {{ $t('creature.slots.loadMore') }}
       </v-btn>
     </v-layout>
     <template v-if="!showDisabled && disabledNodeCount">
@@ -140,7 +140,7 @@
         class="ma-3"
       >
         <div>
-          Requirements of {{ disabledNodeCount }} properties were not met
+          {{ $t('creature.slots.requirementsNotMet', { count: disabledNodeCount }) }}
         </div>
         <v-btn
           class="mt-2"
@@ -148,7 +148,7 @@
           color="accent"
           @click="showDisabled = true"
         >
-          Show All
+          {{ $t('creature.slots.showAll') }}
         </v-btn>
       </v-layout>
     </template>
@@ -157,7 +157,7 @@
         text
         @click="$store.dispatch('popDialogStack')"
       >
-        Cancel
+        {{ $t('creature.slots.cancel') }}
       </v-btn>
       <v-spacer />
       <v-btn
@@ -170,10 +170,10 @@
           {{ totalQuantitySelected }} / {{ model.spaceLeft }}
         </template>
         <template v-if="classId">
-          Insert
+          {{ $t('creature.slots.insert') }}
         </template>
         <template v-else>
-          Close Test
+          {{ $t('creature.slots.closeTest') }}
         </template>
       </v-btn>
     </template>

--- a/app/imports/client/ui/creature/slots/SlotFillDialog.vue
+++ b/app/imports/client/ui/creature/slots/SlotFillDialog.vue
@@ -26,7 +26,7 @@
       :string="model.description"
     />
     <p>
-      {{ slotPropertyTypeName }} with library tags:
+      {{ slotPropertyTypeName }} {{ $t('creature.slots.withLibraryTags') }}
       <property-tags
         v-for="(tags, index) in tagsSearched.or"
         :key="index + 'tags'"
@@ -145,7 +145,7 @@
         outlined
         @click="loadMore"
       >
-        Load More
+        {{ $t('creature.slots.loadMore') }}
       </v-btn>
     </v-layout>
     <template v-if="!showDisabled && disabledNodeCount">
@@ -156,7 +156,7 @@
         class="ma-3 mt-8"
       >
         <div>
-          Requirements of {{ disabledNodeCount }} properties were not met
+          {{ $t('creature.slots.requirementsNotMet', { count: disabledNodeCount }) }}
         </div>
         <v-btn
           class="mt-2"
@@ -165,7 +165,7 @@
           outlined
           @click="showDisabled = true"
         >
-          Show All
+          {{ $t('creature.slots.showAll') }}
         </v-btn>
       </v-layout>
     </template>
@@ -174,7 +174,7 @@
       justify-center
       class="text-caption text--disabled mt-8 mb-2"
     >
-      Can't find what you're looking for?
+      {{ $t('creature.slots.cantFind') }}
     </v-layout>
     <v-layout
       align-center
@@ -190,7 +190,7 @@
         :disabled="!model"
         @click="openLibraryBrowser"
       >
-        Browse community libraries
+        {{ $t('creature.slots.browseLibraries') }}
       </v-btn>
       <v-btn
         v-if="!dummySlot"
@@ -200,7 +200,7 @@
         data-id="custom-button"
         @click="insertCustomFiller"
       >
-        Create custom filler
+        {{ $t('creature.slots.createCustomFiller') }}
       </v-btn>
     </v-layout>
     
@@ -209,7 +209,7 @@
         text
         @click="$store.dispatch('popDialogStack')"
       >
-        Cancel
+        {{ $t('creature.slots.cancel') }}
       </v-btn>
       <v-spacer />
       <v-btn
@@ -222,10 +222,10 @@
           {{ totalQuantitySelected }} / {{ model.spaceLeft }}
         </template>
         <template v-if="slotId">
-          Insert
+          {{ $t('creature.slots.insert') }}
         </template>
         <template v-else>
-          Close Test
+          {{ $t('creature.slots.closeTest') }}
         </template>
       </v-btn>
     </template>

--- a/app/imports/client/ui/dialogStack/DeleteConfirmationDialog.vue
+++ b/app/imports/client/ui/dialogStack/DeleteConfirmationDialog.vue
@@ -1,17 +1,17 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Delete {{ typeName }}
+      {{ $t('dialogStack.deleteConfirmation.delete') }} {{ typeName }}
     </v-toolbar-title>
     <div>
       <v-alert
         type="warning"
         outlined
       >
-        This can't be undone
+        {{ $t('dialogStack.deleteConfirmation.thisCantBeUndone') }}
       </v-alert>
       <p v-if="name">
-        Type "{{ name }}" to permanenetly delete.
+        {{ $t('dialogStack.deleteConfirmation.typeToDelete') }} "{{ name }}" {{ $t('dialogStack.deleteConfirmation.toPermanentlyDelete') }}.
       </p>
       <v-text-field
         v-if="name"
@@ -25,7 +25,7 @@
           class="primary"
           @click="$store.dispatch('popDialogStack', true);"
         >
-          Delete forever
+          {{ $t('dialogStack.deleteConfirmation.deleteForever') }}
         </v-btn>
       </div>
     </div>
@@ -35,7 +35,7 @@
       text
       @click="$store.dispatch('popDialogStack')"
     >
-      Cancel
+      {{ $t('dialogStack.deleteConfirmation.cancel') }}
     </v-btn>
   </dialog-base>
 </template>

--- a/app/imports/client/ui/dialogStack/HelpDialog.vue
+++ b/app/imports/client/ui/dialogStack/HelpDialog.vue
@@ -7,7 +7,7 @@
       mdi-help
     </v-icon>
     <v-toolbar-title slot="toolbar">
-      Help: {{ title }}
+      {{ $t('dialogStack.helpDialog.title') }} {{ title }}
     </v-toolbar-title>
     <div>
       <v-progress-circular
@@ -17,7 +17,7 @@
         size="32"
       />
       <div v-else-if="!doc">
-        Help document not found for {{ title }}
+        {{ $t('dialogStack.helpDialog.helpDocumentNotFound') }} {{ title }}
       </div>
       <markdown-text
         v-else
@@ -31,7 +31,7 @@
       text
       @click="$store.dispatch('popDialogStack')"
     >
-      Close
+      {{ $t('dialogStack.helpDialog.close') }}
     </v-btn>
   </dialog-base>
 </template>

--- a/app/imports/client/ui/docs/DocEditForm.vue
+++ b/app/imports/client/ui/docs/DocEditForm.vue
@@ -11,7 +11,7 @@
             md="6"
           >
             <text-field
-              label="Title"
+              :label="$t('pages.docsEdit.title')"
               :value="doc.name"
               @change="(value, ack) => change({path: ['name'], value, ack})"
             />
@@ -22,9 +22,8 @@
             class="d-flex"
           >
             <text-field
-              label="URL title"
-              :value="doc.urlName"
-              hint="Only letters, numbers, and dashes"
+              :label="$t('pages.docsEdit.urlTitle')"
+              :hint="$t('pages.docsEdit.urlTitleHint')"
               @change="(value, ack) => change({path: ['urlName'], value, ack})"
             />
             <v-menu
@@ -47,7 +46,7 @@
                 >
                   <v-list-item-content>
                     <v-list-item-title>
-                      Delete
+                      {{ $t('pages.docsEdit.delete') }}
                     </v-list-item-title>
                   </v-list-item-content>
                   <v-list-item-action>
@@ -62,7 +61,7 @@
             md="6"
           >
             <smart-switch
-              label="Published"
+              :label="$t('pages.docsEdit.published')"
               :value="doc.published"
               @change="(value, ack) => change({path: ['published'], value, ack})"
             />
@@ -73,7 +72,7 @@
             class="d-flex align-center"
           >
             <icon-picker
-              label="Icon"
+              :label="$t('pages.docsEdit.icon')"
               :value="doc.icon"
               @change="(value, ack) => change({path: ['icon'], value, ack})"
             />
@@ -82,7 +81,7 @@
             cols="12"
           >
             <text-area
-              label="Body"
+              :label="$t('pages.docsEdit.body')"
               :rows="20"
               :value="doc.description"
               @change="(value, ack) => change({path: ['description'], value, ack})"
@@ -119,7 +118,7 @@
             style="width: 100%; height: 240px;"
             @click="ack => add({ ack })"
           >
-            Add child
+            {{ $t('pages.docsEdit.addChild') }}
           </smart-btn>
         </v-col>
       </v-row>

--- a/app/imports/client/ui/files/userImages/ImageInputDialog.vue
+++ b/app/imports/client/ui/files/userImages/ImageInputDialog.vue
@@ -66,7 +66,7 @@
         <v-card-text class="fill-height d-flex flex-column justify-center align-center">
           <v-text-field
             v-model="inputHref"
-            label="Direct link to image"
+            :label="$t('pages.user.directLinkToImage')"
             class="flex-grow-0"
             style="width: 100%"
           />

--- a/app/imports/client/ui/i18n.js
+++ b/app/imports/client/ui/i18n.js
@@ -1,0 +1,23 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+
+// Importa os arquivos de tradução
+import en from '/imports/client/ui/locales/en.json';
+import ptBR from '/imports/client/ui/locales/pt-BR.json';
+
+Vue.use(VueI18n);
+
+// Cria a instância do i18n
+const i18n = new VueI18n({
+  // Tenta pegar o idioma salvo, senão usa inglês
+  locale: localStorage.getItem('locale') || 'en',
+  // Se uma tradução não existir, usa inglês como fallback
+  fallbackLocale: 'en',
+  // Mensagens de tradução
+  messages: {
+    en,
+    'pt-BR': ptBR,
+  },
+});
+
+export default i18n;

--- a/app/imports/client/ui/layouts/Sidebar.vue
+++ b/app/imports/client/ui/layouts/Sidebar.vue
@@ -8,7 +8,7 @@
         text
         to="/sign-in"
       >
-        Sign in
+        {{ $t('layouts.sidebar.signIn') }}
       </v-btn>
     </v-layout>
     <v-list
@@ -32,7 +32,7 @@
                 <v-icon>mdi-cog</v-icon>
               </v-btn>
             </template>
-            <span>Account Settings</span>
+            <span>{{ $t('layouts.sidebar.accountSettings') }}</span>
           </v-tooltip>
         </v-list-item-action>
       </v-list-item>
@@ -95,17 +95,17 @@ export default {
     links() {
       let isLoggedIn = !!Meteor.userId();
       let links = [
-        { title: 'Home', icon: 'mdi-home', to: '/' },
-        { title: 'Characters', icon: 'mdi-account-group', to: '/character-list', requireLogin: true },
-        { title: 'Library', icon: 'mdi-library-shelves', to: '/library', requireLogin: true },
-        { title: 'Tabletops', icon: 'mdi-table-furniture', to: '/tabletops', requireLogin: true },
-        //{ title: 'Friends', icon: 'mdi-account-multiple', to: '/friends', requireLogin: true },
-        { title: 'Files', icon: 'mdi-file-multiple', to: '/my-files', requireLogin: true, },
-        { title: 'Documentation', icon: 'mdi-book-open-variant', to: '/docs' },
-        { title: 'Feedback', icon: 'mdi-bug', to: '/feedback' },
-        { title: 'About', icon: 'mdi-sign-text', to: '/about' },
-        { title: 'Patreon', icon: 'mdi-patreon', href: 'https://www.patreon.com/dicecloud' },
-        { title: 'Github', icon: 'mdi-github', href: 'https://github.com/ThaumRystra/DiceCloud/' },
+        { title: this.$t('layouts.sidebar.links.home'), icon: 'mdi-home', to: '/' },
+        { title: this.$t('layouts.sidebar.links.characters'), icon: 'mdi-account-group', to: '/character-list', requireLogin: true },
+        { title: this.$t('layouts.sidebar.links.library'), icon: 'mdi-library-shelves', to: '/library', requireLogin: true },
+        { title: this.$t('layouts.sidebar.links.tabletops'), icon: 'mdi-table-furniture', to: '/tabletops', requireLogin: true },
+        //{ title: this.$t('layouts.sidebar.links.friends'), icon: 'mdi-account-multiple', to: '/friends', requireLogin: true },
+        { title: this.$t('layouts.sidebar.links.files'), icon: 'mdi-file-multiple', to: '/my-files', requireLogin: true, },
+        { title: this.$t('layouts.sidebar.links.documentation'), icon: 'mdi-book-open-variant', to: '/docs' },
+        { title: this.$t('layouts.sidebar.links.feedback'), icon: 'mdi-bug', to: '/feedback' },
+        { title: this.$t('layouts.sidebar.links.about'), icon: 'mdi-sign-text', to: '/about' },
+        { title: this.$t('layouts.sidebar.links.patreon'), icon: 'mdi-patreon', href: 'https://www.patreon.com/dicecloud' },
+        { title: this.$t('layouts.sidebar.links.github'), icon: 'mdi-github', href: 'https://github.com/ThaumRystra/DiceCloud/' },
       ];
       return links.filter(link => !link.requireLogin || isLoggedIn);
     },

--- a/app/imports/client/ui/library/LibraryAndNode.vue
+++ b/app/imports/client/ui/library/LibraryAndNode.vue
@@ -47,7 +47,7 @@
               <v-card-text>
                 <v-switch
                   v-model="showSecondTree"
-                  label="Show second library tree"
+                  :label="$t('pages.library.showSecondLibraryTree')"
                 />
               </v-card-text>
             </v-card>
@@ -57,7 +57,7 @@
           v-if="!libraryId || canEditLibrary"
           v-model="organize"
           hide-details
-          label="Organize"
+          :label="$t('pages.library.organize')"
           class="ml-1 mr-3 mt-2"
           style="flex-grow: 0; height: 32px;"
         />

--- a/app/imports/client/ui/library/LibraryBrowser.vue
+++ b/app/imports/client/ui/library/LibraryBrowser.vue
@@ -64,7 +64,7 @@
       @click="insertLibrary"
     >
       <v-icon>mdi-plus</v-icon>
-      New library
+      {{ $t('pages.library.newLibrary') }}
     </v-btn>
   </div>
 </template>

--- a/app/imports/client/ui/library/LibraryCollectionCreationDialog.vue
+++ b/app/imports/client/ui/library/LibraryCollectionCreationDialog.vue
@@ -2,31 +2,31 @@
   <dialog-base>
     <template slot="toolbar">
       <v-toolbar-title>
-        New Collection
+        {{ $t('pages.library.newCollection') }}
       </v-toolbar-title>
     </template>
     <template>
       <text-field
-        label="Name"
+        :label="$t('pages.library.name')"
         :value="libraryCollection.name"
         :debounce-time="0"
         @change="nameChanged"
       />
       <text-area
-        label="Description"
+        :label="$t('pages.library.description')"
         :value="libraryCollection.description"
         :debounce-time="0"
         @change="descriptionChanged"
       />
       <smart-select
-        label="Libraries"
+        :label="$t('pages.library.libraries')"
         :items="libraryOptions"
         :value="libraryCollection.libraries"
         :debounce-time="0"
         multiple
         chips
         deletable-chips
-        no-data-text="No libraries found"
+        :no-data-text="$t('pages.library.noLibrariesFound')"
         @change="librariesChanged"
       />
     </template>
@@ -37,7 +37,7 @@
         :disabled="!valid"
         @click="$store.dispatch('popDialogStack', libraryCollection)"
       >
-        Insert Collection
+        {{ $t('pages.library.insertCollection') }}
       </v-btn>
     </template>
   </dialog-base>
@@ -88,7 +88,7 @@ export default {
         ack();
       } else {
         this.valid = false;
-        ack('Name is required')
+        ack(this.$t('pages.library.nameIsRequired'))
       }
     },
     descriptionChanged(val, ack){

--- a/app/imports/client/ui/library/LibraryCollectionEditDialog.vue
+++ b/app/imports/client/ui/library/LibraryCollectionEditDialog.vue
@@ -38,35 +38,35 @@
             {{ ownerName || '?' }}
           </v-list-item-title>
           <v-list-item-subtitle>
-            Collection owner
+            {{ $t('pages.library.collectionOwner') }}
           </v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
       <text-field
-        label="name"
+        :label="$t('pages.library.name')"
         :value="model.name"
         @change="(name, ack) => updateLibraryCollection({name}, ack)"
       />
       <text-area
-        label="Description"
+        :label="$t('pages.library.description')"
         :value="model.description"
         @change="(description, ack) => updateLibraryCollection({description}, ack)"
       />
       <smart-switch
         :value="model.showInMarket"
         :disabled="!isOwner"
-        label="Show in community library browser"
+        :label="$t('pages.library.showInCommunityBrowser')"
         @change="(showInMarket, ack) => updateLibraryCollection({showInMarket}, ack)"
       />
       <smart-select
-        label="Libraries"
+        :label="$t('pages.library.libraries')"
         :items="libraryOptions"
         :value="model.libraries"
         :debounce-time="0"
         multiple
         chips
         deletable-chips
-        no-data-text="No libraries found"
+        :no-data-text="$t('pages.library.noLibrariesFound')"
         @change="(libraries, ack) => updateLibraryCollection({libraries}, ack)"
       />
     </template>
@@ -77,7 +77,7 @@
         data-id="delete-library-button"
         @click="$store.dispatch('popDialogStack')"
       >
-        Done
+        {{ $t('pages.library.done') }}
       </v-btn>
     </template>
   </dialog-base>

--- a/app/imports/client/ui/library/LibraryCollectionToolbar.vue
+++ b/app/imports/client/ui/library/LibraryCollectionToolbar.vue
@@ -24,7 +24,7 @@
       :loading="loading"
       @click="subscribe(!subscribed)"
     >
-      {{ subscribed ? 'Unsubscribe' : 'Subscribe' }}
+      {{ subscribed ? $t('pages.libraryBrowser.Unsubscribe') : $t('pages.libraryBrowser.Subscribe') }}
     </v-btn>
     <v-btn
       v-if="canEdit"
@@ -40,7 +40,7 @@
       slot="extension"
       class="mx-4 text--disabled"
     >
-      {{ formatNumber(libraryCollection.subscriberCount) }} subscribers
+      {{ formatNumber(libraryCollection.subscriberCount) }} {{ $t('pages.library.subscribers') }}
     </div>
   </v-app-bar>
 </template>

--- a/app/imports/client/ui/library/LibraryCreationDialog.vue
+++ b/app/imports/client/ui/library/LibraryCreationDialog.vue
@@ -2,17 +2,17 @@
   <dialog-base>
     <template slot="toolbar">
       <v-toolbar-title>
-        New Library
+        {{ $t('pages.library.newLibrary') }}
       </v-toolbar-title>
     </template>
     <text-field
-      label="Name"
+      :label="$t('pages.library.name')"
       :value="library.name"
       :debounce-time="0"
       @change="nameChanged"
     />
     <text-area
-      label="Description"
+      :label="$t('pages.library.description')"
       :value="library.description"
       :debounce-time="0"
       @change="descriptionChanged"
@@ -24,7 +24,7 @@
         :disabled="!valid"
         @click="$store.dispatch('popDialogStack', library)"
       >
-        Insert Library
+        {{ $t('pages.library.insertLibrary') }}
       </v-btn>
     </template>
   </dialog-base>
@@ -54,7 +54,7 @@ export default {
           ack();
       } else {
         this.valid = false;
-        ack('Name is required')
+        ack(this.$t('pages.library.nameIsRequired'))
       }
     },
     descriptionChanged(val, ack) {

--- a/app/imports/client/ui/library/LibraryEditDialog.vue
+++ b/app/imports/client/ui/library/LibraryEditDialog.vue
@@ -38,29 +38,29 @@
             {{ ownerName }}
           </v-list-item-title>
           <v-list-item-subtitle>
-            Library owner
+            {{ $t('pages.library.libraryOwner') }}
           </v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
       <text-field
-        label="name"
+        :label="$t('pages.library.name')"
         :value="model.name"
         @change="updateName"
       />
       <text-area
-        label="Description"
+        :label="$t('pages.library.description')"
         :value="model.description"
         @change="updateDescription"
       />
       <smart-switch
         :value="model.showInMarket"
         :disabled="!isOwner"
-        label="Show in community library browser"
+        :label="$t('pages.library.showInCommunityBrowser')"
         @change="updateShowInMarket"
       />
     </template>
     <template v-if="removedDocs.length">
-      <h3>Recently Deleted Properties</h3>
+      <h3>{{ $t('pages.library.recentlyDeletedProperties') }}</h3>
       <v-list>
         <v-list-item
           v-for="model in removedDocs"
@@ -77,7 +77,7 @@
               text
               @click="restore(model._id)"
             >
-              Restore
+              {{ $t('pages.library.restore') }}
             </v-btn>
           </v-list-item-action>
         </v-list-item>
@@ -95,7 +95,7 @@
         data-id="delete-library-button"
         @click="$store.dispatch('popDialogStack')"
       >
-        Done
+        {{ $t('pages.library.done') }}
       </v-btn>
     </template>
   </dialog-base>

--- a/app/imports/client/ui/library/LibraryNodeDialog.vue
+++ b/app/imports/client/ui/library/LibraryNodeDialog.vue
@@ -78,14 +78,14 @@
           text
           @click="$store.dispatch('popDialogStack', false)"
         >
-          Cancel
+          {{ $t('pages.library.cancel') }}
         </v-btn>
         <v-spacer />
         <v-btn
           text
           @click="$store.dispatch('popDialogStack', true)"
         >
-          Select
+          {{ $t('pages.library.select') }}
         </v-btn>
       </template>
       <v-btn
@@ -93,7 +93,7 @@
         text
         @click="$store.dispatch('popDialogStack')"
       >
-        Done
+        {{ $t('pages.library.done') }}
       </v-btn>
     </div>
   </dialog-base>

--- a/app/imports/client/ui/library/SingleLibraryToolbar.vue
+++ b/app/imports/client/ui/library/SingleLibraryToolbar.vue
@@ -24,7 +24,7 @@
       :loading="loading"
       @click="subscribe(!subscribed)"
     >
-      {{ subscribed ? 'Unsubscribe' : 'Subscribe' }}
+      {{ subscribed ? $t('pages.libraryBrowser.Unsubscribe') : $t('pages.libraryBrowser.Subscribe') }}
     </v-btn>
     <v-btn
       v-if="canEdit"
@@ -40,7 +40,7 @@
       slot="extension"
       class="mx-4 text--disabled"
     >
-      {{ formatNumber(library.subscriberCount) }} subscribers
+      {{ formatNumber(library.subscriberCount) }} {{ $t('pages.library.subscribers') }}
     </div>
   </v-app-bar>
 </template>

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -138,7 +138,12 @@
       "linkPatreonAccount": "Link Patreon Account",
       "signOut": "Sign Out",
       "invites": "Invites",
-      "deleteAccount": "Delete Account"
+      "deleteAccount": "Delete Account",
+      "language": "Language",
+      "languages": {
+        "en": "English",
+        "pt-br": "Portuguese (Brazil)"
+      }
     },
     "themes": {
       "dark": "Dark",

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -598,6 +598,455 @@
           "continue": "Continue"
         }
       }
+    },
+    "archiveDialog": {
+      "archive": "Archive",
+      "restore": "Restore",
+      "close": "Close"
+    },
+    "creatureList": {
+      "archiveButton": "Archive Characters"
+    },
+    "creatureProperties": {
+      "creaturePropertyDialog": {
+        "close": "Close"
+      },
+      "creaturePropertyFromLibraryDialog": {
+        "addFromLibrary": "Add from library",
+        "insert": "Insert"
+      }
+    },
+    "dependencyGraph": {
+      "dependencyGraphDialog": {
+        "title": "Dependency Graph"
+      }
+    },
+    "experiences": {
+      "experienceForm": {
+        "switch": {
+          "milestone": "Milestone"
+        },
+        "fields": {
+          "levels": "Levels",
+          "name": "Name"
+        }
+      },
+      "experienceInsertDialog": {
+        "addExperience": "Add Experience",
+        "insert": "Insert"
+      },
+      "experienceListDialog": {
+        "title": "Experiences",
+        "noExperiences": "No experiences"
+      }
+    },
+    "slots": {
+      "loadMore": "Load More",
+      "requirementsNotMet": "Requirements of {count} properties were not met",
+      "showAll": "Show All",
+      "insert": "Insert",
+      "closeTest": "Close Test",
+      "withLibraryTags": "with library tags:",
+      "cantFind": "Can't find what you're looking for?",
+      "browseLibraries": "Browse community libraries",
+      "createCustomFiller": "Create custom filler",
+      "slots": "slots",
+      "cancel": "Cancel"
+    },
+    "creatureForm": {
+      "name": "Name",
+      "alignment": "Alignment",
+      "gender": "Gender",
+      "picture": "Picture",
+      "pictureHint": "A link to a high resolution image",
+      "avatar": "Avatar",
+      "avatarHint": "A link to a smaller, square image to use as an avatar",
+      "settings": "Settings",
+      "hideRedundantStats": "Hide redundant stats",
+      "hideRestButtons": "Hide rest buttons",
+      "showSpellsTab": "Show spells tab",
+      "showTreeTab": "Show tree tab",
+      "hitDiceResetMultiplier": "Hit Dice reset multiplier",
+      "hitDiceResetHint": "What fraction of your hit dice are reset every long rest",
+      "discordWebhook": "Discord Webhook URL",
+      "discordWebhookHint": "This creature's logs will be posted to the discord channel",
+      "libraries": "Libraries",
+      "allUserLibraries": "All user libraries",
+      "debug": "Debug",
+      "dependencyGraph": "Dependency Graph"
+    },
+    "creatureFormDialog": {
+      "title": "Character Details",
+      "done": "Done"
+    },
+    "restButton": {
+      "shortRest": "Short Rest",
+      "longRest": "Long Rest"
+    },
+    "buildTree": {
+      "fillSlot": "Fill Slot"
+    },
+    "creatureListItem": {
+      "folder": "Folder",
+      "newCharacter": "New Character",
+      "importCharacter": "Import Character",
+      "addFolder": "Add Folder"
+    }
+  },
+  "properties": {
+    "insertPropertyDialog": {
+      "new": "New",
+      "type": "Type",
+      "create": "Create",
+      "library": "Library",
+      "loadMore": "Load More",
+      "discard": "Discard",
+      "cancel": "Cancel",
+      "insert": "Insert",
+      "property": "Property"
+    },
+    "propertyForm": {
+      "name": "Name",
+      "tags": "Tags",
+      "tagsHint": "Tags let other properties target this property with interactions",
+      "color": "Color",
+      "icon": "Icon",
+      "library": "Library",
+      "canFillSlots": "Can fill slots",
+      "searchable": "Searchable from character sheet",
+      "slotFillType": "Slot fill type",
+      "slotFillTypeHint": "The property type that this slot filler pretends to be when being searched for by a slot",
+      "slotQuantityFilled": "Slot quantity filled",
+      "slotQuantityFilledHint": "How many properties this counts as when filling a slot",
+      "condition": "Condition",
+      "conditionHint": "A calculation to determine if this property can be added to a character",
+      "conditionErrorText": "Condition Error Text",
+      "conditionErrorTextHint": "Text to display if the condition isn't met",
+      "libraryTags": "Library Tags",
+      "libraryTagsHint": "Used to let slots find this property in a library",
+      "childProperties": "Child properties",
+      "other": "...Other",
+      "child": "Child",
+      "childrenCanBeAdded": "Children can be added after this property is created"
+    },
+    "forms": {
+      "common": {
+        "variableName": "Variable name",
+        "variableNameHint": "Use this name in calculations to reference this attribute",
+        "baseValue": "Base Value",
+        "baseValueHint": "This is the value of the attribute before effects are applied. Can be a number or a calculation",
+        "description": "Description",
+        "summary": "Summary",
+        "type": "Type",
+        "resourcesConsumed": "Resources Consumed",
+        "limitUses": "Limit Uses",
+        "uses": "Uses",
+        "usesHint": "How many times this action can be used before needing to be reset",
+        "usesUsed": "Uses used",
+        "usesUsedHint": "How many times this action has already been used: should be 0 in most cases",
+        "damage": "Damage",
+        "damageHint": "Damage reduces the attribute's final value",
+        "behavior": "Behavior",
+        "log": "Log"
+      },
+      "actionForm": {
+        "attackRoll": "Attack roll",
+        "baseAttackRollBonus": "Base attack roll bonus",
+        "baseAttackRollHint": "Must be set for the action to have an attack roll",
+        "actionType": "Action type",
+        "eventVariableName": "Event variable name",
+        "eventVariableNameHint": "Variable name of the event that this action represents",
+        "targetCreature": "Target creature",
+        "singleTarget": "Single Target",
+        "multipleTargets": "Multiple Targets",
+        "self": "Self",
+        "summaryHint": "This will appear in the action card in the character sheet, summarise what the action does. This text will be displayed in the log when the action is taken",
+        "dontShowInLog": "Don't show in log",
+        "action": "Action",
+        "bonusAction": "Bonus action",
+        "attackAction": "Attack action",
+        "attackActionHint": "Attack actions replace a single attack when you choose to use your Action to attack",
+        "reaction": "Reaction",
+        "freeAction": "Free action",
+        "freeActionHint": "You can take one free action on your turn without using an action or bonus action",
+        "longAction": "Long action",
+        "longActionHint": "Long actions take longer than one turn to complete",
+        "event": "Event",
+        "eventHint": "Events are actions that happen to the character like rests or dawn"
+      },
+      "attributeForm": {
+        "hitDiceSize": "Hit Dice Size",
+        "spellSlotLevel": "Spell slot level",
+        "healthBar": "Health Bar",
+        "damagedColors": "Damaged Colors",
+        "half": "Half",
+        "empty": "Empty",
+        "damageOrder": "Damage order",
+        "damageOrderHint": "Lower ordered health bars will take damage before higher ordered ones",
+        "ignoreDamage": "Ignore damage",
+        "preventDamageOverflow": "Prevent damage overflow",
+        "healingOrder": "Healing order",
+        "healingOrderHint": "Lower ordered health bars will take healing before higher ordered ones",
+        "ignoreHealing": "Ignore healing",
+        "preventHealingOverflow": "Prevent healing overflow",
+        "resetHint": "When damage should be reset to zero",
+        "allowDecimalValues": "Allow decimal values",
+        "canBeDamagedNegative": "Can be damaged into negative values",
+        "canBeIncrementedAboveTotal": "Can be incremented above total",
+        "hideWhenTotalZero": "Hide when total is zero",
+        "hideWhenValueZero": "Hide when value is zero",
+        "abilityScore": "Ability score",
+        "abilityScoreHint": "Ability scores are your primary attributes, like Strength and Intelligence",
+        "stat": "Stat",
+        "statHint": "Stats are attributes with a numerical value like speed or carrying capacity",
+        "modifier": "Modifier",
+        "modifierHint": "Modifiers are attributes that are added to rolls, like proficiency bonus",
+        "hitDice": "Hit dice",
+        "resource": "Resource",
+        "resourceHint": "Resources are attributes that are spent to fuel actions, like sorcery points or ki",
+        "spellSlot": "Spell slot",
+        "utility": "Utility",
+        "utilityHint": "Utility attributes aren't displayed on your character sheet, but can be referenced or used in calculations"
+      },
+      "spellForm": {
+        "alwaysPrepared": "Always prepared",
+        "prepared": "Prepared",
+        "castWithoutSpellSlots": "Cast without spell slots",
+        "level": "Level",
+        "levelHint": "The spell level",
+        "school": "School",
+        "castingTime": "Casting Time",
+        "range": "Range",
+        "duration": "Duration",
+        "verbal": "Verbal",
+        "somatic": "Somatic",
+        "concentration": "Concentration",
+        "ritual": "Ritual",
+        "material": "Material",
+        "toHit": "To Hit",
+        "toHitHint": "The bonus to attack if this action has an attack roll",
+        "cantrip": "Cantrip",
+        "abjuration": "Abjuration",
+        "conjuration": "Conjuration",
+        "divination": "Divination",
+        "enchantment": "Enchantment",
+        "evocation": "Evocation",
+        "illusion": "Illusion",
+        "necromancy": "Necromancy",
+        "transmutation": "Transmutation"
+      },
+      "itemForm": {
+        "quantity": "Quantity",
+        "pluralName": "Plural name",
+        "pluralNameHint": "The plural name of your item. If your item's name is 'sword' plural name would be 'swords'",
+        "weight": "Weight",
+        "weightHint": "The weight of a single item in lbs. Can be a decimal value",
+        "value": "Value",
+        "valueHint": "The value of the item in gold pieces, using decimals for values less than 1 gp",
+        "requiresAttunement": "Requires attunement",
+        "attuned": "Attuned",
+        "showIncrement": "Show increment button",
+        "equipped": "Equipped",
+        "attunement": "Attunement"
+      },
+      "effectForm": {
+        "operation": "Operation",
+        "value": "Value",
+        "valueHint": "Number or calculation to determine the value of this effect",
+        "text": "Text",
+        "textHint": "The text to display on the affected stats",
+        "targetProperties": "Target properties",
+        "targetByVariableName": "Target by variable name",
+        "targetByTags": "Target by tags",
+        "stats": "Stats",
+        "statsHint": "Which stats will this effect apply to",
+        "targetField": "Target field",
+        "targetFieldHint": "Target a specific calculation field on the affected properties",
+        "baseValue": "Base Value",
+        "baseValueHint": "Stats take their largest base value, and then apply all other effects",
+        "add": "Add",
+        "addHint": "Add this value to the stat",
+        "multiply": "Multiply",
+        "multiplyHint": "Multiply the stat by this value",
+        "minimum": "Minimum",
+        "minimumHint": "The stat will be at least this value",
+        "maximum": "Maximum",
+        "maximumHint": "The stat will not exceed this value",
+        "set": "Set",
+        "setHint": "The stat will be set to this value",
+        "advantage": "Advantage",
+        "advantageHint": "If this stat is the basis for a check, that check will be at advantage",
+        "disadvantage": "Disadvantage",
+        "disadvantageHint": "If this stat is the basis for a check, that check will be at disadvantage",
+        "passiveBonus": "Passive Bonus",
+        "passiveBonusHint": "This value will be added to the passive check",
+        "fail": "Fail",
+        "failHint": "Targeted skills and checks will always fail",
+        "conditionalBenefit": "Conditional Benefit",
+        "conditionalBenefitHint": "Add a text note to this stat"
+      },
+      "skillForm": {
+        "ability": "Ability",
+        "abilityHint": "Which ability is this skill based off of",
+        "skillType": "Type",
+        "baseProficiency": "Base Proficiency",
+        "baseValues": "Base Values",
+        "baseValueHint": "This is the value of the skill before effects are applied",
+        "applySkill": "Apply skill",
+        "applySkillToTags": "Apply skill to targeted tags",
+        "skill": "Skill",
+        "skillHint": "A normal character sheet skill like Athletics, Deception, or Investigation",
+        "save": "Save",
+        "saveHint": "A saving throw the character can make: Strength Save, etc.",
+        "check": "Check",
+        "checkHint": "An ability check that might include a proficiency bonus later eg. Initiative",
+        "tool": "Tool",
+        "toolHint": "A tool proficiency. Be sure to add a base proficiency in the advanced section.",
+        "weapon": "Weapon",
+        "weaponHint": "A weapon proficiency. Be sure to add a base proficiency in the advanced section.",
+        "armor": "Armor",
+        "armorHint": "An armor proficiency. Be sure to add a base proficiency in the advanced section.",
+        "language": "Language",
+        "languageHint": "A language proficiency. Be sure to add a base proficiency in the advanced section.",
+        "utility": "Utility",
+        "utilityHint": "A skill that does not show up in the sheet, but can be used by other calculations"
+      },
+      "proficiencyForm": {
+        "proficiencyType": "Proficiency Type",
+        "optionAvailable": "Option available"
+      },
+      "slotForm": {
+        "type": "Type",
+        "typeHint": "What property type is needed to fill this slot",
+        "anyType": "Any type",
+        "quantity": "Quantity",
+        "quantityHint": "How many matching properties must be used to fill this slot",
+        "unlimited": "unlimited",
+        "condition": "Condition",
+        "conditionHint": "A calculation to determine if this slot should be active",
+        "alwaysActive": "Always active",
+        "unique": "Unique",
+        "uniqueHint": "Do the properties that fill this slot need to be unique?",
+        "allowDuplicates": "Allow duplicate values",
+        "uniqueInSlot": "Each property inside this slot should be unique",
+        "uniqueInCreature": "Properties in this slot should be unique across the whole character",
+        "testSlot": "Test Slot",
+        "test": "Test",
+        "ignored": "Ignored"
+      },
+      "buffForm": {
+        "targetCreature": "Target creature",
+        "actionTarget": "Action Target",
+        "self": "Self",
+        "children": "Children",
+        "hideRemoveButton": "Hide remove button",
+        "dontFreezeVariables": "Don't freeze variables"
+      },
+      "damageForm": {
+        "damage": "Damage",
+        "damageHint": "A calculation including dice rolls of the damage to deal to the target when activated by an action",
+        "damageType": "Damage Type",
+        "damageTypeHint": "Use the Healing type to restore hit points",
+        "targetCreature": "Target creature",
+        "actionTarget": "Action Target",
+        "self": "Self",
+        "savingThrow": "Saving throw",
+        "dc": "DC",
+        "dcHint": "Saving throw DC",
+        "save": "Save",
+        "saveHint": "Which stat the saving throw targets",
+        "damageOnSuccessfulSave": "Damage on successful save",
+        "damageOnSuccessfulSaveHint": "Use \"~damage\" to reference the damage that would normally be dealt",
+        "halfDamage": "Half damage"
+      },
+      "toggleForm": {
+        "active": "Active",
+        "enabled": "Enabled",
+        "disabled": "Disabled",
+        "calculated": "Calculated",
+        "condition": "Condition",
+        "conditionHint": "When this calculation returns a value that isn't false or zero the children will be active",
+        "enableOrDisable": "Enabled or disable properties",
+        "descendants": "Descendants",
+        "byTargetTags": "By target tags",
+        "showOnCharacterSheet": "Show on character sheet"
+      },
+      "branchForm": {
+        "branchType": "Branch Type",
+        "condition": "Condition",
+        "conditionHint": "If this resolved to a true value, the child properties will be applied",
+        "index": "Index",
+        "indexHint": "Which child to apply. An index of 2 will choose the 2nd child.",
+        "ifConditionTrue": "If condition is true",
+        "attackHit": "Attack hit",
+        "attackMiss": "Attack miss",
+        "saveFailed": "Save failed",
+        "saveSucceeded": "Save succeeded",
+        "applyToEachTarget": "Apply to each target",
+        "random": "Random",
+        "calculatedIndex": "Calculated index",
+        "userChoice": "User choice"
+      },
+      "folderForm": {
+        "grouping": "Grouping",
+        "groupChildrenOnCard": "Group children on a card",
+        "hideChildrenFromDefault": "Hide children from their default locations",
+        "tab": "Tab",
+        "location": "Location",
+        "statsTab": "Stats Tab",
+        "featuresTab": "Features Tab",
+        "actionsTab": "Actions Tab",
+        "spellsTab": "Spells Tab",
+        "inventoryTab": "Inventory Tab",
+        "journalTab": "Journal Tab",
+        "buildTab": "Build Tab",
+        "start": "Start",
+        "end": "End",
+        "afterEvents": "After events",
+        "afterStats": "After stats",
+        "afterSkills": "After skills",
+        "afterProficiencies": "After proficiencies"
+      },
+      "noteForm": {
+        "summaryHint": "This will appear in the card in the character sheet",
+        "descriptionHint": "Text that does not fit in the summary"
+      },
+      "classForm": {
+        "variableNameHint": "Use this name in calculations to reference this class",
+        "classLevelsFromLibraries": "Class levels from libraries",
+        "activeCondition": "Active condition",
+        "activeConditionHint": "A calculation to determine if this class can have class levels added to it"
+      },
+      "featureForm": {
+        "summaryHint": "This will appear in the feature card in the character sheet",
+        "descriptionHint": "The rest of the description that doesn't fit in the summary goes here"
+      },
+      "rollForm": {
+        "variableNameHint": "Use this name in action formulae to refer to the result of this roll",
+        "roll": "Roll",
+        "rollHint": "The calculation that will be evaluated when the roll is triggered by an action. The result will be saved as the variable name in the context of the roll."
+      },
+      "containerForm": {
+        "value": "Value",
+        "valueHint": "The value of the item in gold pieces, using decimals for values less than 1 gp",
+        "weight": "Weight",
+        "carried": "Carried",
+        "carriedHint": "Whether this container and its contents count towards the creature's weight carried",
+        "contentsWeightless": "Contents are weightless"
+      },
+      "triggerForm": {
+        "triggerEvent": "Trigger Event",
+        "triggerCondition": "Trigger Condition",
+        "actionsTaken": "Actions Taken",
+        "timing": "Timing",
+        "timingHint": "When this trigger will fire",
+        "event": "Event",
+        "eventHint": "What causes this trigger to fire",
+        "condition": "Condition",
+        "conditionHint": "A calculation to determine if this trigger should fire",
+        "eventType": "Event Type",
+        "eventTypeHint": "Which action event causes this trigger to fire"
+      }
     }
   }
 }

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -158,6 +158,35 @@
     "docsPage": {
       "notFound": "Documentation not found"
     },
+    "docsEdit": {
+      "title": "Title",
+      "urlTitle": "URL title",
+      "urlTitleHint": "Only letters, numbers, and dashes",
+      "published": "Published",
+      "icon": "Icon",
+      "body": "Body",
+      "delete": "Delete",
+      "addChild": "Add child"
+    },
+    "user": {
+      "username": "Username",
+      "usernameAlreadyTaken": "Username is already taken",
+      "update": "Update",
+      "deleteUserAccount": "Delete User Account",
+      "areYouSure": "Are you sure you want to delete your account?",
+      "deletedAccountsCannotBeRecovered": "Deleted accounts can not be recovered",
+      "immediatelyDeleteData": "We will immediately delete your account and all of your data",
+      "usernameWillBeAvailable": "Your username will become available to anyone on DiceCloud",
+      "charactersWillBeDeleted": "These {count} characters will be deleted:",
+      "characterWillBeDeleted": "This character will be deleted:",
+      "librariesWillBeDeleted": "These {count} libraries will be deleted:",
+      "libraryWillBeDeleted": "This library will be deleted:",
+      "typeUsernameOrEmail": "Type your username or email",
+      "toVerifyType": "To verify type 'delete my account'",
+      "permanentlyDeleteAccount": "Permanently delete account",
+      "cancel": "Cancel",
+      "directLinkToImage": "Direct link to image"
+    },
     "documentation": {
       "notFound": "Help document not found for"
     },
@@ -198,7 +227,28 @@
     },
     "library": {
       "browse": "Browse community libraries",
-      "addCollection": "Add Collection"
+      "addCollection": "Add Collection",
+      "newLibrary": "New Library",
+      "newCollection": "New Collection",
+      "name": "Name",
+      "description": "Description",
+      "libraries": "Libraries",
+      "noLibrariesFound": "No libraries found",
+      "insertLibrary": "Insert Library",
+      "insertCollection": "Insert Collection",
+      "nameIsRequired": "Name is required",
+      "libraryOwner": "Library owner",
+      "collectionOwner": "Collection owner",
+      "showInCommunityBrowser": "Show in community library browser",
+      "recentlyDeletedProperties": "Recently Deleted Properties",
+      "restore": "Restore",
+      "done": "Done",
+      "cancel": "Cancel",
+      "select": "Select",
+      "showSecondLibraryTree": "Show second library tree",
+      "organize": "Organize",
+      "subscribers": "subscribers",
+      "copiedSuccessfully": "Copied successfully"
     },
     "maintenance": {
       "title": "DiceCloud is currently under maintenance"
@@ -280,7 +330,31 @@
     },
     "tabletop": {
       "notFound": "This tabletop was not found",
-      "notFoundDescription": "Either it does not exist, or you do not have permission to view it"
+      "notFoundDescription": "Either it does not exist, or you do not have permission to view it",
+      "name": "Name",
+      "pictureUrl": "Picture URL",
+      "pictureUrlHint": "A link to a cover image for this tabletop",
+      "description": "Description",
+      "sharing": "Sharing",
+      "whoCanView": "Who can view",
+      "onlyPeopleIShareWith": "Only people I share with",
+      "anyoneWithLink": "Anyone with link",
+      "link": "Link",
+      "addUser": "Add user",
+      "usernameOrEmail": "Username or email",
+      "permission": "Permission",
+      "gameMaster": "Game Master",
+      "player": "Player",
+      "spectator": "Spectator",
+      "share": "Share",
+      "owner": "Owner",
+      "gameMasters": "Game Masters",
+      "players": "Players",
+      "spectators": "Spectators",
+      "userAlreadyGameMaster": "User is already a game master",
+      "userAlreadyPlayer": "User is already a player",
+      "userAlreadySpectator": "User is already a spectator",
+      "userNotFound": "User not found"
     },
     "tabletops": {
       "dontHaveAny": "You don't have any tabletops"

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -1,24 +1,4 @@
 {
-  "common": {
-    "save": "Save",
-    "cancel": "Cancel",
-    "delete": "Delete",
-    "edit": "Edit",
-    "add": "Add",
-    "loading": "Loading...",
-    "confirm": "Confirm",
-    "close": "Close",
-    "search": "Search",
-    "back": "Back",
-    "next": "Next",
-    "done": "Done",
-    "yes": "Yes",
-    "no": "No",
-    "ok": "OK",
-    "error": "Error",
-    "success": "Success",
-    "warning": "Warning"
-  },
   "nav": {
     "characters": "Characters",
     "library": "Library",
@@ -112,125 +92,201 @@
     "thisCannotBeUndone": "This can only be undone by the user you are transferring ownership to.",
     "youEditPermission": "You will still have edit permission."
   }, 
-  "home": {
-    "title": "Free, Auditable, real-time character tracking for 5th edition",
-    "subtitle": "Spend less time shuffling paper, and more time playing the game",
-    "register": "Register",
-    "signIn": "Sign In",
-    "myCharacters": "My Characters",
-    "freeOpen": "Free, open source, community funded",
-    "freeOpenDescription": "DiceCloud is free to use, funded via Patreon, and the source code is available on Github under a GPL license.",
-    "customEverything": "Custom everything",
-    "customEverythingDescription": "Add new ability scores, skills, health-bars, and stats to your character. The entire sheet is under your control.",
-    "advancedCharacters": "Advanced Character Engine",
-    "advancedCharactersDescription": "Characters are computed in real-time based on their equipment, features, and buffs.",
-    "getInvolved": "Get involved in the DiceCloud community",
-    "highlightCards": {
-      "automatedActions": "Automated actions",
-      "auditableStats": "Auditable stats",
-      "diceRolling": "Dice rolling",
-      "hackableChar": "Hackable character builder",
-      "dragAndDrop": "Drag and drop inventory manager",
-      "customLibraries": "Custom libraries of content",
-      "discordWebhooks": "Discord webhooks",
-      "printedCharacters": "Printed character sheets"
-    }
-  },
-  "about": {
-    "description": "DiceCloud is a single-developer project started in 2014 with the aim of being a character sheet that stayed in sync between the DM and their players, and made it clear where every value in the sheet came from, and how it was calculated.",
-    "specialThanks": "Special Thanks",
-    "sam": "without her love, DiceCloud could not hope to exist",
-    "heroes": "The D&D party whose joy was the fuel powering the early versions of DiceCloud."
-  },
-  "account": {
-    "fileStorageUsed": "File storage used",
-    "characterStorageUsed": "Character storage used",
-    "preferences": "Preferences",
-    "theme": "Theme",
-    "swapAbilityScoresAndModifiers": "Swap ability scores and modifiers",
-    "username": "Username",
-    "changeUsername": "Change Username",
-    "email": "Email",
-    "patreon": "Patreon",
-    "refreshPatreonStatus": "Refresh Patreon Status",
-    "linkGoogleAccount": "Link Google Account",
-    "linkPatreonAccount": "Link Patreon Account",
-    "signOut": "Sign Out",
-    "invites": "Invites",
-    "deleteAccount": "Delete Account"
-  },
-  "themes": {
-    "dark": "Dark",
-    "matchDeviceTheme": "Match device theme",
-    "light": "Light"
-  },
-  "characterList": {
-    "alert": {
-      "exceededLimit": "You have exceeded your maximum number of character slots, archive or delete some characters.",
-      "limit": "You have hit your maximum number of characters.",
-      "or": "or",
-      "increasePatreon": "Increase Patreon tier"
+  "pages": {
+    "home": {
+      "title": "Free, Auditable, real-time character tracking for 5th edition",
+      "subtitle": "Spend less time shuffling paper, and more time playing the game",
+      "register": "Register",
+      "signIn": "Sign In",
+      "myCharacters": "My Characters",
+      "freeOpen": "Free, open source, community funded",
+      "freeOpenDescription": "DiceCloud is free to use, funded via Patreon, and the source code is available on Github under a GPL license.",
+      "customEverything": "Custom everything",
+      "customEverythingDescription": "Add new ability scores, skills, health-bars, and stats to your character. The entire sheet is under your control.",
+      "advancedCharacters": "Advanced Character Engine",
+      "advancedCharactersDescription": "Characters are computed in real-time based on their equipment, features, and buffs.",
+      "getInvolved": "Get involved in the DiceCloud community",
+      "highlightCards": {
+        "automatedActions": "Automated actions",
+        "auditableStats": "Auditable stats",
+        "diceRolling": "Dice rolling",
+        "hackableChar": "Hackable character builder",
+        "dragAndDrop": "Drag and drop inventory manager",
+        "customLibraries": "Custom libraries of content",
+        "discordWebhooks": "Discord webhooks",
+        "printedCharacters": "Printed character sheets"
+      }
     },
-    "importCharacter": "Import Character",
-    "addFolder": "Add Folder"
-  },
-  "docsPage": {
-    "notFound": "Documentation not found"
-  },
-  "documentation": {
-    "notFound": "Help document not found for"
-  },
-  "emailVerificationError": {
-    "title": "Email Verification Error"
-  },
-  "emailVerificationSuccess": {
-    "title": "Email Verified",
-    "subtitle": "Your email address has been verified"
-  },
-  "feedback": {
-    "discordServer": "DiceCloud Discord server",
-    "discordDescriptionServer": "To give feedback or get support using DiceCloud, join the official Discord server",
-    "join": "Join"
-  },
-  "filePage": {
-    "archivedChar": "Archived Characters",
-    "images": "Image",
-    "uploadArchive": "Upload Archive",
-    "uploadImage": "Upload Image",
-    "errors": {
-      "mustBeJson": "File must be .json",
-      "fileTooLarge": "File too large",
-      "fileCouldntBeParsed": "File could not be parsed",
-      "fileFailedValidation": "File failed validation: "
+    "about": {
+      "description": "DiceCloud is a single-developer project started in 2014 with the aim of being a character sheet that stayed in sync between the DM and their players, and made it clear where every value in the sheet came from, and how it was calculated.",
+      "specialThanks": "Special Thanks",
+      "sam": "without her love, DiceCloud could not hope to exist",
+      "heroes": "The D&D party whose joy was the fuel powering the early versions of DiceCloud."
+    },
+    "account": {
+      "fileStorageUsed": "File storage used",
+      "characterStorageUsed": "Character storage used",
+      "preferences": "Preferences",
+      "theme": "Theme",
+      "swapAbilityScoresAndModifiers": "Swap ability scores and modifiers",
+      "username": "Username",
+      "changeUsername": "Change Username",
+      "email": "Email",
+      "patreon": "Patreon",
+      "refreshPatreonStatus": "Refresh Patreon Status",
+      "linkGoogleAccount": "Link Google Account",
+      "linkPatreonAccount": "Link Patreon Account",
+      "signOut": "Sign Out",
+      "invites": "Invites",
+      "deleteAccount": "Delete Account"
+    },
+    "themes": {
+      "dark": "Dark",
+      "matchDeviceTheme": "Match device theme",
+      "light": "Light"
+    },
+    "characterList": {
+      "alert": {
+        "exceededLimit": "You have exceeded your maximum number of character slots, archive or delete some characters.",
+        "limit": "You have hit your maximum number of characters.",
+        "or": "or",
+        "increasePatreon": "Increase Patreon tier"
+      },
+      "importCharacter": "Import Character",
+      "addFolder": "Add Folder"
+    },
+    "docsPage": {
+      "notFound": "Documentation not found"
+    },
+    "documentation": {
+      "notFound": "Help document not found for"
+    },
+    "emailVerificationError": {
+      "title": "Email Verification Error"
+    },
+    "emailVerificationSuccess": {
+      "title": "Email Verified",
+      "subtitle": "Your email address has been verified"
+    },
+    "feedback": {
+      "discordServer": "DiceCloud Discord server",
+      "discordDescriptionServer": "To give feedback or get support using DiceCloud, join the official Discord server",
+      "join": "Join"
+    },
+    "filePage": {
+      "archivedChar": "Archived Characters",
+      "images": "Image",
+      "uploadArchive": "Upload Archive",
+      "uploadImage": "Upload Image",
+      "errors": {
+        "mustBeJson": "File must be .json",
+        "fileTooLarge": "File too large",
+        "fileCouldntBeParsed": "File could not be parsed",
+        "fileFailedValidation": "File failed validation: "
+      }
+    },
+    "inviteError": {
+      "title": "Invite Error"
+    },
+    "inviteSuccess": {
+      "title": "Invite Success",
+      "description": "You can now use DiceCloud"
+    },
+    "launchCountdown": {
+      "title": "DiceCloud version 2 beta will launch in",
+      "description": "days,"
+    },
+    "library": {
+      "browse": "Browse community libraries",
+      "addCollection": "Add Collection"
+    },
+    "maintenance": {
+      "title": "DiceCloud is currently under maintenance"
+    },
+    "notFound": {
+      "title": "No page was found for this address"
+    },
+    "notImplemented": {
+      "title": "This page is not available in this version of DiceCloud."
+    },
+    "patreonLevelTooLow": {
+      "currentTier": "Your current Patreon tier is",
+      "description": "You need to be at least Adventurer tier (or be invited by a Patron of a higher tier) to access this beta",
+      "joinNow": "Join now"
+    },
+    "register": {
+      "email": "Email",
+      "username": "Username",
+      "password": "Password",
+      "password2": "Password Again",
+      "register": "Register",
+      "googleLogin": "Register in with Google",
+      "errors": {
+        "nameIsRequired": "Name is required",
+        "emailIsRequired": "E-mail is required",
+        "emailIsInvalid": "E-mail must be valid",
+        "passwordIsRequired": "Password is required",
+        "passwordsDontMatch": "Passwords don't match"
+      }
+    },
+    "resetPassword": {
+      "password": "New Password",
+      "password2": "Password Again",
+      "email": "Email",
+      "resetPassword": "Reset Password",
+      "errors": {
+        "emailIsRequired": "E-mail is required",
+        "emailIsInvalid": "E-mail must be valid",
+        "passwordIsRequired": "Password is required",
+        "passwordsDontMatch": "Passwords don't match"
+      },
+      "passwordResetLink": "Password reset link sent to "
+    },
+    "signIn": {
+      "usernameOrEmail": "Username or Email",
+      "password": "Password",
+      "resetPassword": "Reset Password",
+      "signIn": "Sign In",
+      "register": "Register",
+      "diceV2": "DiceCloud Version 2 requires a new account to use.",
+      "diceV1": "Version 1 is still available at",
+      "googleLogin": "Sign In in with Google",
+      "signInPatreon": "Sign In with Patreon",
+      "errors": {
+        "nameIsRequired": "Name is required",
+        "emailIsRequired": "E-mail is required",
+        "emailIsInvalid": "E-mail must be valid",
+        "passwordIsRequired": "Password is required",
+        "passwordsDontMatch": "Passwords don't match"
+      }
+    },
+    "friends": {
+      "title": "Friends"
+    },
+    "admin": {
+      "currentDatabaseVersion": "Current database version:",
+      "databaseIsUpToDate": "Database is up to date with latest version. Restart to enable navigation.",
+      "expectedDatabaseVersion": "Expected database version:",
+      "gitVersion": "Git version:",
+      "backUpTheDatabase": "Back up the database before attempting any migration. A failed migration can result in profound data loss.",
+      "migrateTo": "Migrate to database version"
+    },
+    "functionReference": {
+      "title": "Functions"
+    },
+    "libraryBrowser": {
+      "Unsubscribe": "Unsubscribe",
+      "Subscribe": "Subscribe"
+    },
+    "tabletop": {
+      "notFound": "This tabletop was not found",
+      "notFoundDescription": "Either it does not exist, or you do not have permission to view it"
+    },
+    "tabletops": {
+      "dontHaveAny": "You don't have any tabletops"
+    },
+    "singleLibrary": {
+      "title": "Library"
     }
-  },
-  "inviteError": {
-    "title": "Invite Error"
-  },
-  "inviteSuccess": {
-    "title": "Invite Success",
-    "description": "You can now use DiceCloud"
-  },
-  "launchCountdown": {
-    "title": "DiceCloud version 2 beta will launch in",
-    "description": "days,"
-  },
-  "library": {
-    "browse": "Browse community libraries",
-    "addCollection": "Add Collection"
-  },
-  "maintenance": {
-    "title": "DiceCloud is currently under maintenance"
-  },
-  "notFound": {
-    "title": "No page was found for this address"
-  },
-  "notImplemented": {
-    "title": "This page is not available in this version of DiceCloud."
-  },
-  "patreonLevelTooLow": {
-    "currentTier": "Your current Patreon tier is",
-    "description": "You need to be at least Adventurer tier (or be invited by a Patron of a higher tier) to access this beta",
-    "joinNow": "Join now"
   }
 }

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -1,0 +1,177 @@
+{
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "add": "Add",
+    "loading": "Loading...",
+    "confirm": "Confirm",
+    "close": "Close",
+    "search": "Search",
+    "back": "Back",
+    "next": "Next",
+    "done": "Done",
+    "yes": "Yes",
+    "no": "No",
+    "ok": "OK",
+    "error": "Error",
+    "success": "Success",
+    "warning": "Warning"
+  },
+  "nav": {
+    "characters": "Characters",
+    "library": "Library",
+    "tabletop": "Tabletop",
+    "settings": "Settings",
+    "home": "Home",
+    "signIn": "Sign In",
+    "signOut": "Sign Out",
+    "account": "Account"
+  },
+  "character": {
+    "create": "Create Character",
+    "newCharacter": "New Character",
+    "name": "Character Name",
+    "level": "Level",
+    "class": "Class",
+    "race": "Race",
+    "background": "Background",
+    "alignment": "Alignment",
+    "experiencePoints": "Experience Points",
+    "hitPoints": "Hit Points",
+    "armorClass": "Armor Class",
+    "speed": "Speed",
+    "initiative": "Initiative",
+    "proficiencyBonus": "Proficiency Bonus",
+    "stats": "Stats",
+    "actions": "Actions",
+    "spells": "Spells",
+    "inventory": "Inventory",
+    "features": "Features",
+    "journal": "Journal",
+    "build": "Build"
+  },
+  "abilities": {
+    "strength": "Strength",
+    "dexterity": "Dexterity",
+    "constitution": "Constitution",
+    "intelligence": "Intelligence",
+    "wisdom": "Wisdom",
+    "charisma": "Charisma"
+  },
+  "tabletop": {
+    "addCharacter": "Add Character",
+    "addCreature": "Add Creature",
+    "gameMasters": "Game Masters",
+    "players": "Players",
+    "spectators": "Spectators",
+    "owner": "Owner",
+    "initiative": "Initiative",
+    "round": "Round"
+  },
+  "actions": {
+    "attack": "Attack",
+    "cast": "Cast",
+    "use": "Use",
+    "roll": "Roll",
+    "damage": "Damage",
+    "heal": "Heal",
+    "rest": "Rest",
+    "shortRest": "Short Rest",
+    "longRest": "Long Rest"
+  },
+  "errors": {
+    "notFound": "Not found",
+    "unauthorized": "You are not authorized to perform this action",
+    "invalidInput": "Invalid input",
+    "serverError": "Server error. Please try again later."
+  },
+  "share": {
+    "title": "Sharing",
+    "whoCanView": "Who can view",
+    "onlyPeopleIShareWith": "Only people I share with",
+    "anyoneWithLink": "Anyone with link",
+    "whoCanCopy": "Who can copy",
+    "onlyPeopleWithEditPermission": "Only people with edit permission",
+    "anyoneWithReadPermission": "Anyone with read permission",
+    "textFieldPlaceholder": "Username or email",
+    "shareButton": "Share",
+    "permission": {
+      "reader": "View only",
+      "writer": "Can edit"
+    },
+    "transferOwnership": "Transfer Ownership",
+    "remove": "Remove",
+    "confirm": "Done"
+  },
+  "transferOwnershipDialog": {
+    "title": "Transfer Ownership",
+    "confirm": "Transfer to",
+    "areYouSure": "Are you sure you want to transfer ownership of this character to ",
+    "thisCannotBeUndone": "This can only be undone by the user you are transferring ownership to.",
+    "youEditPermission": "You will still have edit permission."
+  }, 
+  "home": {
+    "title": "Free, Auditable, real-time character tracking for 5th edition",
+    "subtitle": "Spend less time shuffling paper, and more time playing the game",
+    "register": "Register",
+    "signIn": "Sign In",
+    "myCharacters": "My Characters",
+    "freeOpen": "Free, open source, community funded",
+    "freeOpenDescription": "DiceCloud is free to use, funded via Patreon, and the source code is available on Github under a GPL license.",
+    "customEverything": "Custom everything",
+    "customEverythingDescription": "Add new ability scores, skills, health-bars, and stats to your character. The entire sheet is under your control.",
+    "advancedCharacters": "Advanced Character Engine",
+    "advancedCharactersDescription": "Characters are computed in real-time based on their equipment, features, and buffs.",
+    "getInvolved": "Get involved in the DiceCloud community",
+    "highlightCards": {
+      "automatedActions": "Automated actions",
+      "auditableStats": "Auditable stats",
+      "diceRolling": "Dice rolling",
+      "hackableChar": "Hackable character builder",
+      "dragAndDrop": "Drag and drop inventory manager",
+      "customLibraries": "Custom libraries of content",
+      "discordWebhooks": "Discord webhooks",
+      "printedCharacters": "Printed character sheets"
+    }
+  },
+  "about": {
+    "description": "DiceCloud is a single-developer project started in 2014 with the aim of being a character sheet that stayed in sync between the DM and their players, and made it clear where every value in the sheet came from, and how it was calculated.",
+    "specialThanks": "Special Thanks",
+    "sam": "without her love, DiceCloud could not hope to exist",
+    "heroes": "The D&D party whose joy was the fuel powering the early versions of DiceCloud."
+  },
+  "account": {
+    "fileStorageUsed": "File storage used",
+    "characterStorageUsed": "Character storage used",
+    "preferences": "Preferences",
+    "theme": "Theme",
+    "swapAbilityScoresAndModifiers": "Swap ability scores and modifiers",
+    "username": "Username",
+    "changeUsername": "Change Username",
+    "email": "Email",
+    "patreon": "Patreon",
+    "refreshPatreonStatus": "Refresh Patreon Status",
+    "linkGoogleAccount": "Link Google Account",
+    "linkPatreonAccount": "Link Patreon Account",
+    "signOut": "Sign Out",
+    "invites": "Invites",
+    "deleteAccount": "Delete Account"
+  },
+  "themes": {
+    "dark": "Dark",
+    "matchDeviceTheme": "Match device theme",
+    "light": "Light"
+  },
+  "characterList": {
+    "alert": {
+      "exceededLimit": "You have exceeded your maximum number of character slots, archive or delete some characters.",
+      "limit": "You have hit your maximum number of characters.",
+      "or": "or",
+      "increasePatreon": "Increase Patreon tier"
+    },
+    "importCharacter": "Import Character",
+    "addFolder": "Add Folder"
+  }
+}

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -173,5 +173,64 @@
     },
     "importCharacter": "Import Character",
     "addFolder": "Add Folder"
+  },
+  "docsPage": {
+    "notFound": "Documentation not found"
+  },
+  "documentation": {
+    "notFound": "Help document not found for"
+  },
+  "emailVerificationError": {
+    "title": "Email Verification Error"
+  },
+  "emailVerificationSuccess": {
+    "title": "Email Verified",
+    "subtitle": "Your email address has been verified"
+  },
+  "feedback": {
+    "discordServer": "DiceCloud Discord server",
+    "discordDescriptionServer": "To give feedback or get support using DiceCloud, join the official Discord server",
+    "join": "Join"
+  },
+  "filePage": {
+    "archivedChar": "Archived Characters",
+    "images": "Image",
+    "uploadArchive": "Upload Archive",
+    "uploadImage": "Upload Image",
+    "errors": {
+      "mustBeJson": "File must be .json",
+      "fileTooLarge": "File too large",
+      "fileCouldntBeParsed": "File could not be parsed",
+      "fileFailedValidation": "File failed validation: "
+    }
+  },
+  "inviteError": {
+    "title": "Invite Error"
+  },
+  "inviteSuccess": {
+    "title": "Invite Success",
+    "description": "You can now use DiceCloud"
+  },
+  "launchCountdown": {
+    "title": "DiceCloud version 2 beta will launch in",
+    "description": "days,"
+  },
+  "library": {
+    "browse": "Browse community libraries",
+    "addCollection": "Add Collection"
+  },
+  "maintenance": {
+    "title": "DiceCloud is currently under maintenance"
+  },
+  "notFound": {
+    "title": "No page was found for this address"
+  },
+  "notImplemented": {
+    "title": "This page is not available in this version of DiceCloud."
+  },
+  "patreonLevelTooLow": {
+    "currentTier": "Your current Patreon tier is",
+    "description": "You need to be at least Adventurer tier (or be invited by a Patron of a higher tier) to access this beta",
+    "joinNow": "Join now"
   }
 }

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -555,6 +555,49 @@
           "maxPrepared": "Maximum prepared spells"
         }
       }
+    },
+    "actions": {
+      "done": "Done",
+      "input": {
+        "advantageInput": {
+          "disadvantage": "Disadvantage",
+          "advantage": "Advantage",
+          "roll": "Roll"
+        },
+        "castSpellInput": {
+          "clear": "Clear",
+          "done": "Done",
+          "slot": "Slot",
+          "castWithoutSpellSlot": "Cast without spell slot",
+          "castAsRitual": "Cast as ritual",
+          "spell": "Spell",
+          "cantrip": "Cantrip",
+          "level": "Level",
+          "fields": {
+            "name": "Name"
+            
+          }
+        },
+        "checkInput": {
+          "roll": "Roll",
+          "advantage": "Advantage",
+          "disadvantage": "Disadvantage",
+          "select": {
+            "ability": "Ability",
+            "skill": "Skill"
+          },
+          "dc": "DC"
+        },
+        "choiceInput": {
+          "done": "Done"
+        },
+        "targetsInput": {
+          "singleTarget": "Target",
+          "multipleTargets": "Targets",
+          "noTarget": "No target",
+          "continue": "Continue"
+        }
+      }
     }
   }
 }

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -288,5 +288,73 @@
     "singleLibrary": {
       "title": "Library"
     }
+  },
+  "layouts": {
+    "sidebar": {
+      "signIn": "Sign In",
+      "accountSettings": "Account Settings",
+      "links": {
+        "home": "Home",
+        "characters": "Characters",
+        "library": "Library",
+        "tabletops": "Tabletops",
+        "friends": "Friends",
+        "files": "Files",
+        "documentation": "Documentation",
+        "feedback": "Feedback",
+        "about": "About",
+        "patreon": "Patreon",
+        "github": "Github"
+      }
+    }
+  },
+  "dialogStack": {
+    "deleteConfirmation": {
+      "delete": "Delete",
+      "thisCantBeUndone": "This can't be undone",
+      "typeToDelete": "Type",
+      "toPermanentlyDelete": "to permanently delete.",
+      "deleteForever": "Delete forever",
+      "cancel": "Cancel"
+    },
+    "helpDialog": {
+      "title": "Help:",
+      "helpDocumentNotFound": "Help document not found for",
+      "close": "Close"
+    }
+  },
+  "components": {
+    "iconPicker": {
+      "searchIcons": "Search icons",
+      "clear": "clear"
+    },
+    "treeSearch": {
+      "search": "Search",
+      "type": "Type",
+      "field": "Field",
+      "text": "Text",
+      "clear": "Clear",
+      "find": "Find"
+    },
+    "resetSelector": {
+      "reset": "Reset",
+      "shortRest": "Short rest",
+      "longRest": "Long rest"
+    },
+    "colorPicker": {
+      "clear": "Clear",
+      "done": "Done"
+    },
+    "propertyToolbar": {
+      "help": "Help",
+      "duplicate": "Duplicate",
+      "copyTo": "Copy To",
+      "createReference": "Create Reference",
+      "move": "Move",
+      "copyToLibrary": "Copy to library",
+      "delete": "Delete",
+      "done": "Done",
+      "edit": "Edit"
+    }
   }
 }

--- a/app/imports/client/ui/locales/en.json
+++ b/app/imports/client/ui/locales/en.json
@@ -356,5 +356,205 @@
       "done": "Done",
       "edit": "Edit"
     }
+  },
+  "creature": {
+    "character": {
+      "characterSheet": {
+        "characterSheet": "Character Sheet",
+        "notFound": "Character not found",
+        "notFoundDescription": "Either it does not exist, or you do not have permission to view it",
+        "stats": "Stats",
+        "actions": "Actions",
+        "spells": "Spells",
+        "inventory": "Inventory",
+        "features": "Features",
+        "journal": "Journal",
+        "build": "Build"
+      },
+      "characterCreationDialog": {
+        "title": "New Character",
+        "biography": "Biography",
+        "libraries": "Libraries",
+        "build": "Build",
+        "fields": {
+          "name": "Name",
+          "race": "Race",
+          "class": "Class",
+          "gender": "Gender",
+          "alignment": "Alignment",
+          "level": "Level"
+        },
+        "allUserLibraries": "All User Libraries",
+        "cancel": "Cancel",
+        "create": "Create",
+        "back": "Back",
+        "next": "Next"
+      },
+      "characterDeleteDialog": {
+        "title": "Delete Character",
+        "typeToDelete": "Type",
+        "toPermanentlyDelete": "to permanently delete the character",
+        "deleteForever": "Delete forever",
+        "cancel": "Cancel"
+      },
+      "characterImportDialog": {
+        "title": "Import Character",
+        "importCharacter": "Import a character from another instance of DiceCloud",
+        "importCharacterDescription": "The character needs to have their sharing permission set to \"anyone can view\"",
+        "import": "Import",
+        "cancel": "Cancel",
+        "errors": {
+          "noUserId": "No user ID. Are you logged in?",
+          "ackNoUserId": "This character's sharing settings are not set to allow anyone to view"
+        }
+      },
+      "characterSheetToolbar": {
+        "sheetOwner": "Sheet owner",
+        "share": "Sharing",
+        "unshareWithMe": "Unshare with me",
+        "print": "Print",
+        "editDetails": "Edit details",
+        "delete": "Delete",
+        "tab": {
+          "stats": "Stats",
+          "actions": "Actions",
+          "spells": "Spells",
+          "inventory": "Inventory",
+          "features": "Features",
+          "journal": "Journal",
+          "build": "Build",
+          "tree": "Tree"
+        }
+      },
+      "creatureRootDialog": {
+        "close": "Close"
+      },
+      "miniCharacterSheet": {
+        "characterSheet": "Character sheet"
+      },
+      "characterSheetTabs": {
+        "buildTab": {
+          "hidden": "hidden",
+          "level": "Level",
+          "milestoneLevels": "Milestone levels",
+          "gettingMissingLevels": "Getting Missing Levels",
+          "levelUp": "Level Up",
+          "slots": "Slots"
+        },
+        "inventoryTab": {
+          "weightCarried": "Weight Carried",
+          "netWorth": "Net worth",
+          "itemsAttuned": "Items attuned",
+          "equipped": "Equipped",
+          "carried": "Carried"
+        },
+        "statsTab": {
+          "buffsAndConditions": "Buffs and conditions",
+          "hitDice": "Hit Dice",
+          "hitPoints": "Hit Points",
+          "savingThrows": "Saving Throws",
+          "skills": "Skills",
+          "weapons": "Weapons",
+          "armor": "Armor",
+          "equipment": "Equipment",
+          "tools": "Tools",
+          "languages": "Languages"
+        }
+      },
+      "errors": {
+        "dependencyLoopError": {
+          "theCharacterContains": "The character contains a dependency loop.",
+          "aSetOfPropertiesMayHaveBeenCalculatedIncorrectly": "A set of properties may have been calculated incorrectly, because they form an infinite loop:"
+        }
+      },
+      "printedCharacterSheet": {
+        "notFound": "Character not found",
+        "notFoundDescription": "Either this character does not exist, or you don't have permission to view it.",
+        "level": "Level",
+        "printPrefix": "Print",
+        "inventory": {
+          "title": "Inventory",
+          "weightCarried": "Weight Carried",
+          "netWorth": "Net worth",
+          "itemsAttuned": "Items attuned",
+          "equipped": "Equipped",
+          "carried": "Carried",
+          "each": "each",
+          "lb": "lb",
+          "contents": "contents",
+          "attuned": "Attuned",
+          "requiresAttunement": "Requires attunement"
+        },
+        "spells": {
+          "title": "Spells"
+        },
+        "stats": {
+          "total": "Total",
+          "hitDice": "Hit Dice",
+          "savingThrows": "Saving Throws",
+          "skills": "Skills",
+          "weapons": "Weapons",
+          "armor": "Armor",
+          "tools": "Tools",
+          "languages": "Languages",
+          "proficiencies": "Proficiencies",
+          "spellSlots": "Spell Slots",
+          "shield": "Shield"
+        },
+        "actions": {
+          "uses": "uses",
+          "cost": "Cost",
+          "usesCap": "Uses",
+          "toHit": "to hit",
+          "types": {
+            "action": "Action",
+            "bonus": "Bonus Action",
+            "attack": "Attack",
+            "reaction": "Reaction",
+            "free": "Free Action",
+            "long": "Long Action"
+          }
+        },
+        "damageMultipliers": {
+          "immunity": "Immunity",
+          "resistance": "Resistance",
+          "vulnerability": "Vulnerability",
+          "for": "For",
+          "except": "Except"
+        },
+        "skill": {
+          "fail": "fail"
+        },
+        "spell": {
+          "level": {
+            "cantrip": "cantrip",
+            "0": "cantrip",
+            "1": "1st-level",
+            "2": "2nd-level",
+            "3": "3rd-level",
+            "4": "4th-level",
+            "5": "5th-level",
+            "6": "6th-level",
+            "7": "7th-level",
+            "8": "8th-level",
+            "9": "9th-level",
+            "generic": "{level}-level"
+          },
+          "ritual": "(ritual)",
+          "toHit": "To hit",
+          "castingTime": "Casting time",
+          "range": "Range",
+          "components": "Components",
+          "duration": "Duration"
+        },
+        "spellList": {
+          "saveDc": "Spell Save DC",
+          "ability": "Spell casting ability",
+          "abilityMod": "Spell casting ability modifier",
+          "attackBonus": "Spell Attack Bonus",
+          "maxPrepared": "Maximum prepared spells"
+        }
+      }
+    }
   }
 }

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -1,0 +1,177 @@
+{
+  "common": {
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "add": "Adicionar",
+    "loading": "Carregando...",
+    "confirm": "Confirmar",
+    "close": "Fechar",
+    "search": "Buscar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "done": "Concluído",
+    "yes": "Sim",
+    "no": "Não",
+    "ok": "OK",
+    "error": "Erro",
+    "success": "Sucesso",
+    "warning": "Aviso"
+  },
+  "nav": {
+    "characters": "Personagens",
+    "library": "Biblioteca",
+    "tabletop": "Mesa",
+    "settings": "Configurações",
+    "home": "Início",
+    "signIn": "Entrar",
+    "signOut": "Sair",
+    "account": "Conta"
+  },
+  "character": {
+    "create": "Criar Personagem",
+    "newCharacter": "Novo Personagem",
+    "name": "Nome do Personagem",
+    "level": "Nível",
+    "class": "Classe",
+    "race": "Raça",
+    "background": "Antecedente",
+    "alignment": "Alinhamento",
+    "experiencePoints": "Pontos de Experiência",
+    "hitPoints": "Pontos de Vida",
+    "armorClass": "Classe de Armadura",
+    "speed": "Deslocamento",
+    "initiative": "Iniciativa",
+    "proficiencyBonus": "Bônus de Proficiência",
+    "stats": "Status",
+    "actions": "Ações",
+    "spells": "Magias",
+    "inventory": "Inventário",
+    "features": "Habilidades",
+    "journal": "Diário",
+    "build": "Ficha"
+  },
+  "abilities": {
+    "strength": "Força",
+    "dexterity": "Destreza",
+    "constitution": "Constituição",
+    "intelligence": "Inteligência",
+    "wisdom": "Sabedoria",
+    "charisma": "Carisma"
+  },
+  "tabletop": {
+    "addCharacter": "Adicionar Personagem",
+    "addCreature": "Adicionar Criatura",
+    "gameMasters": "Mestres",
+    "players": "Jogadores",
+    "spectators": "Espectadores",
+    "owner": "Dono",
+    "initiative": "Iniciativa",
+    "round": "Rodada"
+  },
+  "actions": {
+    "attack": "Atacar",
+    "cast": "Conjurar",
+    "use": "Usar",
+    "roll": "Rolar",
+    "damage": "Dano",
+    "heal": "Curar",
+    "rest": "Descansar",
+    "shortRest": "Descanso Curto",
+    "longRest": "Descanso Longo"
+  },
+  "errors": {
+    "notFound": "Não encontrado",
+    "unauthorized": "Você não tem permissão para realizar esta ação",
+    "invalidInput": "Entrada inválida",
+    "serverError": "Erro no servidor. Tente novamente mais tarde."
+  },
+  "share": {
+    "title": "Compartilhamento",
+    "whoCanView": "Quem pode ver",
+    "onlyPeopleIShareWith": "Apenas as pessoas que eu compartilho",
+    "anyoneWithLink": "Qualquer um com link",
+    "whoCanCopy": "Quem pode copiar",
+    "onlyPeopleWithEditPermission": "Apenas as pessoas com permissão de edição",
+    "anyoneWithReadPermission": "Qualquer um com permissão de leitura",
+    "textFieldPlaceholder": "Usuário ou email",
+    "shareButton": "Compartilhar",
+    "permission": {
+      "reader": "Apenas leitura",
+      "writer": "Pode editar"
+    },
+    "transferOwnership": "Transferir Ficha",
+    "remove": "Remover",
+    "confirm": "Confirmar"
+  },
+  "transferOwnershipDialog": {
+    "title": "Transferir Ficha",
+    "confirm": "Transferir para",
+    "areYouSure": "Você tem certeza que deseja transferir a ficha deste personagem para ",
+    "thisCannotBeUndone": "Isso pode ser desfeito apenas pelo usuário que receberá a ficha.",
+    "youEditPermission": "Você ainda terá permissão de edição."
+  },
+  "home": {
+    "title": "Gratuito, Auditável, controle de personagens em tempo real para 5ª edição",
+    "subtitle": "Gaste menos tempo montando ficha e mais tempo jogando o jogo",
+    "register": "Cadastre-se",
+    "signIn": "Entrar",
+    "myCharacters": "Meus Personagens",
+    "freeOpen": "Gratuito, código aberto, financiado pela comunidade",
+    "freeOpenDescription": "DiceCloud é gratuito para uso, financiado via Patreon, e o código-fonte está disponível no Github sob uma licença GPL.",
+    "customEverything": "Customize tudo",
+    "customEverythingDescription": "Adicione novos pontos de habilidade, habilidades, barras de vida e status para seu personagem. A ficha inteira está sob seu controle.",
+    "advancedCharacters": "Engine de personagem avançada",
+    "advancedCharactersDescription": "Personagens são calculados em tempo real com base em seus equipamentos, habilidades e buffs.",
+    "getInvolved": "Entre na comunidade DiceCloud",
+    "highlightCards": {
+      "automatedActions": "Ações automatizadas",
+      "auditableStats": "Status auditáveis",
+      "diceRolling": "Rolagem de dados",
+      "hackableChar": "Personagens customizáveis",
+      "dragAndDrop": "Gerenciador de inventário drag and drop",
+      "customLibraries": "Bibliotecas de conteúdo personalizadas",
+      "discordWebhooks": "Webhooks do Discord",
+      "printedCharacters": "Fichas de personagem impressas"
+    }
+  },
+  "about": {
+    "description": "O DiceCloud é um projeto desenvolvido por um só desenvolvedor que começou em 2014 com o objetivo de ser uma ficha de personagem que ficasse sincronizada entre o mestre e seus jogadores, e deixasse claro de onde vinha cada valor da ficha e como era calculado.",
+    "specialThanks": "Agradecimentos Especiais",
+    "sam": "Sem seu amor, DiceCloud não esperava existir",
+    "heroes": "O grupo de jogadores que trouxeram alegria para alimentar as versões iniciais do DiceCloud."
+  },
+  "account": {
+  "fileStorageUsed": "Armazenamento usado",
+  "characterStorageUsed": "Armazenamento de personagens usado",
+  "preferences": "Preferências",
+  "theme": "Tema",
+  "swapAbilityScoresAndModifiers": "Swap pontos de habilidade e modificadores",
+  "username": "Nome de usuário",
+  "changeUsername": "Mudar nome de usuário",
+  "email": "Email",
+  "patreon": "Patreon",
+  "refreshPatreonStatus": "Atualizar status do Patreon",
+  "linkGoogleAccount": "Link Google Account",
+  "linkPatreonAccount": "Link Patreon Account",
+  "signOut": "Sair",
+  "invites": "Convites",
+  "deleteAccount": "Deletar conta"
+  },
+  "themes": {
+    "dark": "Escuro",
+    "matchDeviceTheme": "Dispositivo",
+    "light": "Claro"
+  },
+  "characterList": {
+    "alert": {
+      "exceededLimit": "Você excedeu o número máximo de slots de personagem, arquive ou delete alguns personagens.",
+      "limit": "Você atingiu o número máximo de personagens.",
+      "or": "ou",
+      "increasePatreon": "Aumente o seu tier no Patreon"
+    },
+    "importCharacter": "Importar Personagem",
+    "addFolder": "Criar uma pasta"
+  }
+}

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -173,5 +173,64 @@
     },
     "importCharacter": "Importar Personagem",
     "addFolder": "Criar uma pasta"
+  },
+  "docsPage": {
+    "notFound": "Documentação não encontrada"
+  },
+  "documentation": {
+    "notFound": "Documentação de ajuda não encontrada para"
+  },
+  "emailVerificationError": {
+    "title": "Erro na verificação do email"
+  },
+  "emailVerificationSuccess": {
+    "title": "Email Verificado",
+    "subtitle": "Endereço de email verificado"
+  },
+  "feedback": {
+    "discordServer": "DiceCloud Discord server",
+    "discordDescriptionServer": "Para dar feedback ou obter suporte ao usar DiceCloud, junte-se ao servidor Discord oficial",
+    "join": "Entrar"
+  },
+  "filePage": {
+    "archivedChar": "Personagens arquivados",
+    "images": "Imagens",
+    "uploadArchive": "Upload Arquivo",
+    "uploadImage": "Upload Imagem",
+    "errors": {
+      "mustBeJson": "Arquivo deve ser .json",
+      "fileTooLarge": "Arquivo muito grande",
+      "fileCouldntBeParsed": "Arquivo não pode ser analisado",
+      "fileFailedValidation": "Arquivo falhou na validação: "
+    }
+  },
+  "inviteError": {
+    "title": "Erro de convite"
+  },
+  "inviteSuccess": {
+    "title": "Convite bem-sucedido",
+    "description": "Você pode agora usar DiceCloud"
+  },
+  "launchCountdown": {
+    "title": "DiceCloud versão 2 beta lançará em",
+    "description": "dias,"
+  },
+  "library": {
+    "browse": "Pesquise nas bibliotecas da comunidade",
+    "addCollection": "Adicionar na coleção"
+  },
+  "maintenance": {
+    "title": "DiceCloud está atualmente em manutenção"
+  },
+  "notFound": {
+    "title": "Nenhuma página foi encontrada para esta endereço"
+  },
+  "notImplemented": {
+    "title": "Esta página não está disponível nesta versão do DiceCloud."
+  },
+  "patreonLevelTooLow": {
+    "currentTier": "Seu tier atual do Patreon é",
+    "description": "Você precisa ser pelo menos um tier de Adventurer (ou ser convidado por um Patron de um tier mais alto) para acessar esta beta",
+    "joinNow": "Entrar agora"
   }
 }

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -112,125 +112,198 @@
     "thisCannotBeUndone": "Isso pode ser desfeito apenas pelo usuário que receberá a ficha.",
     "youEditPermission": "Você ainda terá permissão de edição."
   },
-  "home": {
-    "title": "Gratuito, Auditável, controle de personagens em tempo real para 5ª edição",
-    "subtitle": "Gaste menos tempo montando ficha e mais tempo jogando o jogo",
-    "register": "Cadastre-se",
-    "signIn": "Entrar",
-    "myCharacters": "Meus Personagens",
-    "freeOpen": "Gratuito, código aberto, financiado pela comunidade",
-    "freeOpenDescription": "DiceCloud é gratuito para uso, financiado via Patreon, e o código-fonte está disponível no Github sob uma licença GPL.",
-    "customEverything": "Customize tudo",
-    "customEverythingDescription": "Adicione novos pontos de habilidade, habilidades, barras de vida e status para seu personagem. A ficha inteira está sob seu controle.",
-    "advancedCharacters": "Engine de personagem avançada",
-    "advancedCharactersDescription": "Personagens são calculados em tempo real com base em seus equipamentos, habilidades e buffs.",
-    "getInvolved": "Entre na comunidade DiceCloud",
-    "highlightCards": {
-      "automatedActions": "Ações automatizadas",
-      "auditableStats": "Status auditáveis",
-      "diceRolling": "Rolagem de dados",
-      "hackableChar": "Personagens customizáveis",
-      "dragAndDrop": "Gerenciador de inventário drag and drop",
-      "customLibraries": "Bibliotecas de conteúdo personalizadas",
-      "discordWebhooks": "Webhooks do Discord",
-      "printedCharacters": "Fichas de personagem impressas"
-    }
-  },
-  "about": {
-    "description": "O DiceCloud é um projeto desenvolvido por um só desenvolvedor que começou em 2014 com o objetivo de ser uma ficha de personagem que ficasse sincronizada entre o mestre e seus jogadores, e deixasse claro de onde vinha cada valor da ficha e como era calculado.",
-    "specialThanks": "Agradecimentos Especiais",
-    "sam": "Sem seu amor, DiceCloud não esperava existir",
-    "heroes": "O grupo de jogadores que trouxeram alegria para alimentar as versões iniciais do DiceCloud."
-  },
-  "account": {
-  "fileStorageUsed": "Armazenamento usado",
-  "characterStorageUsed": "Armazenamento de personagens usado",
-  "preferences": "Preferências",
-  "theme": "Tema",
-  "swapAbilityScoresAndModifiers": "Swap pontos de habilidade e modificadores",
-  "username": "Nome de usuário",
-  "changeUsername": "Mudar nome de usuário",
-  "email": "Email",
-  "patreon": "Patreon",
-  "refreshPatreonStatus": "Atualizar status do Patreon",
-  "linkGoogleAccount": "Link Google Account",
-  "linkPatreonAccount": "Link Patreon Account",
-  "signOut": "Sair",
-  "invites": "Convites",
-  "deleteAccount": "Deletar conta"
-  },
-  "themes": {
-    "dark": "Escuro",
-    "matchDeviceTheme": "Dispositivo",
-    "light": "Claro"
-  },
-  "characterList": {
-    "alert": {
-      "exceededLimit": "Você excedeu o número máximo de slots de personagem, arquive ou delete alguns personagens.",
-      "limit": "Você atingiu o número máximo de personagens.",
-      "or": "ou",
-      "increasePatreon": "Aumente o seu tier no Patreon"
+  "pages": {
+    "home": {
+      "title": "Gratuito, Auditável, controle de personagens em tempo real para 5ª edição",
+      "subtitle": "Gaste menos tempo montando ficha e mais tempo jogando o jogo",
+      "register": "Cadastre-se",
+      "signIn": "Entrar",
+      "myCharacters": "Meus Personagens",
+      "freeOpen": "Gratuito, código aberto, financiado pela comunidade",
+      "freeOpenDescription": "DiceCloud é gratuito para uso, financiado via Patreon, e o código-fonte está disponível no Github sob uma licença GPL.",
+      "customEverything": "Customize tudo",
+      "customEverythingDescription": "Adicione novos pontos de habilidade, habilidades, barras de vida e status para seu personagem. A ficha inteira está sob seu controle.",
+      "advancedCharacters": "Engine de personagem avançada",
+      "advancedCharactersDescription": "Personagens são calculados em tempo real com base em seus equipamentos, habilidades e buffs.",
+      "getInvolved": "Entre na comunidade DiceCloud",
+      "highlightCards": {
+        "automatedActions": "Ações automatizadas",
+        "auditableStats": "Status auditáveis",
+        "diceRolling": "Rolagem de dados",
+        "hackableChar": "Personagens customizáveis",
+        "dragAndDrop": "Gerenciador de inventário drag and drop",
+        "customLibraries": "Bibliotecas de conteúdo personalizadas",
+        "discordWebhooks": "Webhooks do Discord",
+        "printedCharacters": "Fichas de personagem impressas"
+      }
     },
-    "importCharacter": "Importar Personagem",
-    "addFolder": "Criar uma pasta"
-  },
-  "docsPage": {
-    "notFound": "Documentação não encontrada"
-  },
-  "documentation": {
-    "notFound": "Documentação de ajuda não encontrada para"
-  },
-  "emailVerificationError": {
-    "title": "Erro na verificação do email"
-  },
-  "emailVerificationSuccess": {
-    "title": "Email Verificado",
-    "subtitle": "Endereço de email verificado"
-  },
-  "feedback": {
-    "discordServer": "DiceCloud Discord server",
-    "discordDescriptionServer": "Para dar feedback ou obter suporte ao usar DiceCloud, junte-se ao servidor Discord oficial",
-    "join": "Entrar"
-  },
-  "filePage": {
-    "archivedChar": "Personagens arquivados",
-    "images": "Imagens",
-    "uploadArchive": "Upload Arquivo",
-    "uploadImage": "Upload Imagem",
-    "errors": {
-      "mustBeJson": "Arquivo deve ser .json",
-      "fileTooLarge": "Arquivo muito grande",
-      "fileCouldntBeParsed": "Arquivo não pode ser analisado",
-      "fileFailedValidation": "Arquivo falhou na validação: "
+    "about": {
+      "description": "O DiceCloud é um projeto desenvolvido por um só desenvolvedor que começou em 2014 com o objetivo de ser uma ficha de personagem que ficasse sincronizada entre o mestre e seus jogadores, e deixasse claro de onde vinha cada valor da ficha e como era calculado.",
+      "specialThanks": "Agradecimentos Especiais",
+      "sam": "Sem seu amor, DiceCloud não esperava existir",
+      "heroes": "O grupo de jogadores que trouxeram alegria para alimentar as versões iniciais do DiceCloud."
+    },
+    "account": {
+      "fileStorageUsed": "Armazenamento usado",
+      "characterStorageUsed": "Armazenamento de personagens usado",
+      "preferences": "Preferências",
+      "theme": "Tema",
+      "swapAbilityScoresAndModifiers": "Swap pontos de habilidade e modificadores",
+      "username": "Nome de usuário",
+      "changeUsername": "Mudar nome de usuário",
+      "email": "Email",
+      "patreon": "Patreon",
+      "refreshPatreonStatus": "Atualizar status do Patreon",
+      "linkGoogleAccount": "Link Google Account",
+      "linkPatreonAccount": "Link Patreon Account",
+      "signOut": "Sair",
+      "invites": "Convites",
+      "deleteAccount": "Deletar conta"
+    },
+    "themes": {
+      "dark": "Escuro",
+      "matchDeviceTheme": "Dispositivo",
+      "light": "Claro"
+    },
+    "characterList": {
+      "alert": {
+        "exceededLimit": "Você excedeu o número máximo de slots de personagem, arquive ou delete alguns personagens.",
+        "limit": "Você atingiu o número máximo de personagens.",
+        "or": "ou",
+        "increasePatreon": "Aumente o seu tier no Patreon"
+      },
+      "importCharacter": "Importar Personagem",
+      "addFolder": "Criar uma pasta"
+    },
+    "docsPage": {
+      "notFound": "Documentação não encontrada"
+    },
+    "documentation": {
+      "notFound": "Documentação de ajuda não encontrada para"
+    },
+    "emailVerificationError": {
+      "title": "Erro na verificação do email"
+    },
+    "emailVerificationSuccess": {
+      "title": "Email Verificado",
+      "subtitle": "Endereço de email verificado"
+    },
+    "feedback": {
+      "discordServer": "DiceCloud Discord server",
+      "discordDescriptionServer": "Para dar feedback ou obter suporte ao usar DiceCloud, junte-se ao servidor Discord oficial",
+      "join": "Entrar"
+    },
+    "filePage": {
+      "archivedChar": "Personagens arquivados",
+      "images": "Imagens",
+      "uploadArchive": "Upload Arquivo",
+      "uploadImage": "Upload Imagem",
+      "errors": {
+        "mustBeJson": "Arquivo deve ser .json",
+        "fileTooLarge": "Arquivo muito grande",
+        "fileCouldntBeParsed": "Arquivo não pode ser analisado",
+        "fileFailedValidation": "Arquivo falhou na validação: "
+      }
+    },
+    "inviteError": {
+      "title": "Erro de convite"
+    },
+    "inviteSuccess": {
+      "title": "Convite bem-sucedido",
+      "description": "Você pode agora usar DiceCloud"
+    },
+    "launchCountdown": {
+      "title": "DiceCloud versão 2 beta lançará em",
+      "description": "dias,"
+    },
+    "library": {
+      "browse": "Pesquise nas bibliotecas da comunidade",
+      "addCollection": "Adicionar na coleção"
+    },
+    "maintenance": {
+      "title": "DiceCloud está atualmente em manutenção"
+    },
+    "notFound": {
+      "title": "Nenhuma página foi encontrada para esta endereço"
+    },
+    "notImplemented": {
+      "title": "Esta página não está disponível nesta versão do DiceCloud."
+    },
+    "patreonLevelTooLow": {
+      "currentTier": "Seu tier atual do Patreon é",
+      "description": "Você precisa ser pelo menos um tier de Adventurer (ou ser convidado por um Patron de um tier mais alto) para acessar esta beta",
+      "joinNow": "Entrar agora"
+    },
+    "register": {
+      "email": "Email",
+      "username": "Nome de usuário",
+      "password": "Senha",
+      "password2": "Senha novamente",
+      "register": "Cadastrar",
+      "googleLogin": "Cadastrar com Google",
+      "errors": {
+        "nameIsRequired": "Nome de usuário é obrigatório",
+        "emailIsRequired": "Email é obrigatório",
+        "emailIsInvalid": "Email deve ser válido",
+        "passwordIsRequired": "Senha é obrigatória",
+        "passwordsDontMatch": "As senhas não coincidem"
+      }
+    },
+    "resetPassword": {
+      "password": "Nova Senha",
+      "password2": "Senha novamente",
+      "email": "Email",
+      "resetPassword": "Redefinir senha",
+      "errors": {
+        "emailIsRequired": "E-mail é obrigatório",
+        "emailIsInvalid": "E-mail deve ser válido",
+        "passwordIsRequired": "Senha é obrigatória",
+        "passwordsDontMatch": "As senhas não coincidem"
+      },
+      "passwordResetLink": "Link de redefinição de senha enviado para "
+    },
+    "signIn": {
+      "usernameOrEmail": "Nome de usuário ou email",
+      "password": "Senha",
+      "resetPassword": "Redefinir senha",
+      "signIn": "Entrar",
+      "register": "Cadastrar",
+      "diceV2": "DiceCloud Version 2 requer uma nova conta para usar.",
+      "diceV1": "Version 1 ainda está disponível em",
+      "googleLogin": "Entrar com Google",
+      "signInPatreon": "Entrar com Patreon",
+      "errors": {
+        "nameIsRequired": "Nome de usuário é obrigatório",
+        "emailIsRequired": "Email é obrigatório",
+        "emailIsInvalid": "Email deve ser válido",
+        "passwordIsRequired": "Senha é obrigatória",
+        "passwordsDontMatch": "As senhas não coincidem"
+      }
+    },
+    "friends": {
+      "title": "Amigos"
+    },
+    "admin": {
+      "currentDatabaseVersion": "Versão atual do banco de dados:",
+      "databaseIsUpToDate": "Banco de dados está atualizado com a versão mais recente. Reinicie para habilitar a navegação.",
+      "expectedDatabaseVersion": "Versão esperada do banco de dados:",
+      "gitVersion": "Versão do Git:",
+      "backUpTheDatabase": "Faça backup do banco de dados antes de tentar qualquer migração. Uma migração falhada pode resultar em perda de dados profunda.",
+      "migrateTo": "Migrar para a versão do banco de dados"
+    },
+    "functionReference": {
+      "title": "Funções"
+    },
+    "libraryBrowser": {
+      "Unsubscribe": "Cancelar Inscrição",
+      "Subscribe": "Inscrever-se"
+    },
+    "tabletop": {
+      "notFound": "Esta mesa não foi encontrada",
+      "notFoundDescription": "Pode não existir ou você pode não ter permissão para vê-la"
+    },
+    "tabletops": {
+      "dontHaveAny": "Você não tem nenhuma mesa"
     }
-  },
-  "inviteError": {
-    "title": "Erro de convite"
-  },
-  "inviteSuccess": {
-    "title": "Convite bem-sucedido",
-    "description": "Você pode agora usar DiceCloud"
-  },
-  "launchCountdown": {
-    "title": "DiceCloud versão 2 beta lançará em",
-    "description": "dias,"
-  },
-  "library": {
-    "browse": "Pesquise nas bibliotecas da comunidade",
-    "addCollection": "Adicionar na coleção"
-  },
-  "maintenance": {
-    "title": "DiceCloud está atualmente em manutenção"
-  },
-  "notFound": {
-    "title": "Nenhuma página foi encontrada para esta endereço"
-  },
-  "notImplemented": {
-    "title": "Esta página não está disponível nesta versão do DiceCloud."
-  },
-  "patreonLevelTooLow": {
-    "currentTier": "Seu tier atual do Patreon é",
-    "description": "Você precisa ser pelo menos um tier de Adventurer (ou ser convidado por um Patron de um tier mais alto) para acessar esta beta",
-    "joinNow": "Entrar agora"
   }
 }

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -178,6 +178,35 @@
     "docsPage": {
       "notFound": "Documentação não encontrada"
     },
+    "docsEdit": {
+      "title": "Título",
+      "urlTitle": "Título da URL",
+      "urlTitleHint": "Apenas letras, números e hífens",
+      "published": "Publicado",
+      "icon": "Ícone",
+      "body": "Corpo",
+      "delete": "Excluir",
+      "addChild": "Adicionar filho"
+    },
+    "user": {
+      "username": "Nome de usuário",
+      "usernameAlreadyTaken": "Nome de usuário já está em uso",
+      "update": "Atualizar",
+      "deleteUserAccount": "Excluir Conta do Usuário",
+      "areYouSure": "Tem certeza que deseja excluir sua conta?",
+      "deletedAccountsCannotBeRecovered": "Contas excluídas não podem ser recuperadas",
+      "immediatelyDeleteData": "Excluiremos imediatamente sua conta e todos os seus dados",
+      "usernameWillBeAvailable": "Seu nome de usuário ficará disponível para qualquer pessoa no DiceCloud",
+      "charactersWillBeDeleted": "Estes {count} personagens serão excluídos:",
+      "characterWillBeDeleted": "Este personagem será excluído:",
+      "librariesWillBeDeleted": "Estas {count} bibliotecas serão excluídas:",
+      "libraryWillBeDeleted": "Esta biblioteca será excluída:",
+      "typeUsernameOrEmail": "Digite seu nome de usuário ou email",
+      "toVerifyType": "Para verificar digite 'delete my account'",
+      "permanentlyDeleteAccount": "Excluir conta permanentemente",
+      "cancel": "Cancelar",
+      "directLinkToImage": "Link direto para imagem"
+    },
     "documentation": {
       "notFound": "Documentação de ajuda não encontrada para"
     },
@@ -218,7 +247,28 @@
     },
     "library": {
       "browse": "Pesquise nas bibliotecas da comunidade",
-      "addCollection": "Adicionar na coleção"
+      "addCollection": "Adicionar Coleção",
+      "newLibrary": "Nova Biblioteca",
+      "newCollection": "Nova Coleção",
+      "name": "Nome",
+      "description": "Descrição",
+      "libraries": "Bibliotecas",
+      "noLibrariesFound": "Nenhuma biblioteca encontrada",
+      "insertLibrary": "Inserir Biblioteca",
+      "insertCollection": "Inserir Coleção",
+      "nameIsRequired": "Nome é obrigatório",
+      "libraryOwner": "Dono da biblioteca",
+      "collectionOwner": "Dono da coleção",
+      "showInCommunityBrowser": "Mostrar no navegador da comunidade",
+      "recentlyDeletedProperties": "Propriedades Excluídas Recentemente",
+      "restore": "Restaurar",
+      "done": "Concluído",
+      "cancel": "Cancelar",
+      "select": "Selecionar",
+      "showSecondLibraryTree": "Mostrar segunda árvore de biblioteca",
+      "organize": "Organizar",
+      "subscribers": "inscritos",
+      "copiedSuccessfully": "Copiado com sucesso"
     },
     "maintenance": {
       "title": "DiceCloud está atualmente em manutenção"
@@ -300,7 +350,31 @@
     },
     "tabletop": {
       "notFound": "Esta mesa não foi encontrada",
-      "notFoundDescription": "Pode não existir ou você pode não ter permissão para vê-la"
+      "notFoundDescription": "Pode não existir ou você pode não ter permissão para vê-la",
+      "name": "Nome",
+      "pictureUrl": "URL da Imagem",
+      "pictureUrlHint": "Um link para uma imagem de capa desta mesa",
+      "description": "Descrição",
+      "sharing": "Compartilhamento",
+      "whoCanView": "Quem pode ver",
+      "onlyPeopleIShareWith": "Apenas pessoas que eu compartilho",
+      "anyoneWithLink": "Qualquer um com link",
+      "link": "Link",
+      "addUser": "Adicionar usuário",
+      "usernameOrEmail": "Nome de usuário ou email",
+      "permission": "Permissão",
+      "gameMaster": "Mestre",
+      "player": "Jogador",
+      "spectator": "Espectador",
+      "share": "Compartilhar",
+      "owner": "Dono",
+      "gameMasters": "Mestres",
+      "players": "Jogadores",
+      "spectators": "Espectadores",
+      "userAlreadyGameMaster": "Usuário já é um mestre",
+      "userAlreadyPlayer": "Usuário já é um jogador",
+      "userAlreadySpectator": "Usuário já é um espectador",
+      "userNotFound": "Usuário não encontrado"
     },
     "tabletops": {
       "dontHaveAny": "Você não tem nenhuma mesa"

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -304,6 +304,9 @@
     },
     "tabletops": {
       "dontHaveAny": "Você não tem nenhuma mesa"
+    },
+    "singleLibrary": {
+      "title": "Biblioteca"
     }
   },
   "layouts": {
@@ -377,6 +380,7 @@
   "creature": {
     "character": {
       "characterSheet": {
+        "characterSheet": "Ficha do Personagem",
         "notFound": "Personagem não encontrado",
         "notFoundDescription": "Pode não existir ou você pode não ter permissão para vê-lo",
         "stats": "Status",
@@ -588,7 +592,10 @@
           "castAsRitual": "Como ritual",
           "spell": "Magia",
           "cantrip": "Truque",
-          "level": "Nível"
+          "level": "Nível",
+          "fields": {
+            "name": "Nome"
+          }
         },
         "checkInput": {
           "roll": "Rodar",
@@ -609,6 +616,466 @@
           "noTarget": "Sem alvo",
           "continue": "Continuar"
         }
+      }
+    },
+    "archiveDialog": {
+      "archive": "Arquivar",
+      "restore": "Restaurar",
+      "close": "Fechar"
+    },
+    "creatureList": {
+      "archiveButton": "Arquivar personagens"
+    },
+    "creatureProperties": {
+      "creaturePropertyDialog": {
+        "close": "Fechar"
+      },
+      "creaturePropertyFromLibraryDialog": {
+        "addFromLibrary": "Adicionar da biblioteca",
+        "insert": "Inserir"
+      }
+    },
+    "dependencyGraph": {
+      "dependencyGraphDialog": {
+        "title": "Grafo de dependência"
+      }
+    },
+    "experiences": {
+      "experienceForm": {
+        "switch": {
+          "milestone": "Milestone"
+        },
+        "fields": {
+          "levels": "Níveis",
+          "name": "Nome"
+        }
+      },
+      "experienceInsertDialog": {
+        "addExperience": "Adicionar experiência",
+        "insert": "Inserir"
+      },
+      "experienceListDialog": {
+        "title": "Experiências",
+        "noExperiences": "Nenhuma experiência"
+      }
+    },
+    "slots": {
+      "loadMore": "Carregar Mais",
+      "requirementsNotMet": "Requisitos de {count} propriedades não foram atendidos",
+      "showAll": "Mostrar Todos",
+      "insert": "Inserir",
+      "closeTest": "Fechar Teste",
+      "withLibraryTags": "com tags de biblioteca:",
+      "cantFind": "Não encontrou o que procurava?",
+      "browseLibraries": "Navegar nas bibliotecas da comunidade",
+      "createCustomFiller": "Criar preenchimento personalizado",
+      "slots": "slots",
+      "cancel": "Cancelar"
+    },
+    "creatureForm": {
+      "name": "Nome",
+      "alignment": "Alinhamento",
+      "gender": "Gênero",
+      "picture": "Imagem",
+      "pictureHint": "Um link para uma imagem de alta resolução",
+      "avatar": "Avatar",
+      "avatarHint": "Um link para uma imagem quadrada menor para usar como avatar",
+      "settings": "Configurações",
+      "hideRedundantStats": "Ocultar estatísticas redundantes",
+      "hideRestButtons": "Ocultar botões de descanso",
+      "showSpellsTab": "Mostrar aba de magias",
+      "showTreeTab": "Mostrar aba de árvore",
+      "hitDiceResetMultiplier": "Multiplicador de reset dos dados de vida",
+      "hitDiceResetHint": "Qual fração dos seus dados de vida são resetados a cada descanso longo",
+      "discordWebhook": "URL do Webhook do Discord",
+      "discordWebhookHint": "Os logs desta criatura serão postados no canal do Discord",
+      "libraries": "Bibliotecas",
+      "allUserLibraries": "Todas as bibliotecas do usuário",
+      "debug": "Debug",
+      "dependencyGraph": "Grafo de Dependências"
+    },
+    "creatureFormDialog": {
+      "title": "Detalhes do Personagem",
+      "done": "Concluído"
+    },
+    "restButton": {
+      "shortRest": "Descanso Curto",
+      "longRest": "Descanso Longo"
+    },
+    "buildTree": {
+      "fillSlot": "Preencher Slot"
+    },
+    "creatureListItem": {
+      "folder": "Pasta",
+      "newCharacter": "Novo Personagem",
+      "importCharacter": "Importar Personagem",
+      "addFolder": "Adicionar Pasta"
+    }
+  },
+  "properties": {
+    "insertPropertyDialog": {
+      "new": "Novo",
+      "type": "Tipo",
+      "create": "Criar",
+      "library": "Biblioteca",
+      "loadMore": "Carregar Mais",
+      "discard": "Descartar",
+      "cancel": "Cancelar",
+      "insert": "Inserir",
+      "property": "Propriedade"
+    },
+    "propertyForm": {
+      "name": "Nome",
+      "tags": "Tags",
+      "tagsHint": "Tags permitem que outras propriedades interajam com esta propriedade",
+      "color": "Cor",
+      "icon": "Ícone",
+      "library": "Biblioteca",
+      "canFillSlots": "Pode preencher slots",
+      "searchable": "Pesquisável na ficha do personagem",
+      "slotFillType": "Tipo de preenchimento de slot",
+      "slotFillTypeHint": "O tipo de propriedade que este preenchedor finge ser quando procurado por um slot",
+      "slotQuantityFilled": "Quantidade de slot preenchida",
+      "slotQuantityFilledHint": "Quantas propriedades isso conta ao preencher um slot",
+      "condition": "Condição",
+      "conditionHint": "Um cálculo para determinar se esta propriedade pode ser adicionada a um personagem",
+      "conditionErrorText": "Texto de Erro da Condição",
+      "conditionErrorTextHint": "Texto a exibir se a condição não for atendida",
+      "libraryTags": "Tags da Biblioteca",
+      "libraryTagsHint": "Usado para que slots encontrem esta propriedade em uma biblioteca",
+      "childProperties": "Propriedades filhas",
+      "other": "...Outros",
+      "child": "Filho",
+      "childrenCanBeAdded": "Filhos podem ser adicionados após esta propriedade ser criada"
+    },
+    "forms": {
+      "common": {
+        "variableName": "Nome da variável",
+        "variableNameHint": "Use este nome em cálculos para referenciar este atributo",
+        "baseValue": "Valor Base",
+        "baseValueHint": "Este é o valor do atributo antes dos efeitos serem aplicados. Pode ser um número ou um cálculo",
+        "description": "Descrição",
+        "summary": "Resumo",
+        "type": "Tipo",
+        "resourcesConsumed": "Recursos Consumidos",
+        "limitUses": "Limitar Usos",
+        "uses": "Usos",
+        "usesHint": "Quantas vezes esta ação pode ser usada antes de precisar ser reiniciada",
+        "usesUsed": "Usos utilizados",
+        "usesUsedHint": "Quantas vezes esta ação já foi usada: deve ser 0 na maioria dos casos",
+        "damage": "Dano",
+        "damageHint": "Dano reduz o valor final do atributo",
+        "behavior": "Comportamento",
+        "log": "Registro"
+      },
+      "actionForm": {
+        "attackRoll": "Rolagem de ataque",
+        "baseAttackRollBonus": "Bônus base de rolagem de ataque",
+        "baseAttackRollHint": "Deve ser definido para a ação ter uma rolagem de ataque",
+        "actionType": "Tipo de ação",
+        "eventVariableName": "Nome da variável do evento",
+        "eventVariableNameHint": "Nome da variável do evento que esta ação representa",
+        "targetCreature": "Criatura alvo",
+        "singleTarget": "Alvo Único",
+        "multipleTargets": "Múltiplos Alvos",
+        "self": "Próprio",
+        "summaryHint": "Isso aparecerá no cartão de ação na ficha do personagem, resumindo o que a ação faz. Este texto será exibido no registro quando a ação for realizada",
+        "dontShowInLog": "Não mostrar no registro",
+        "action": "Ação",
+        "bonusAction": "Ação bônus",
+        "attackAction": "Ação de ataque",
+        "attackActionHint": "Ações de ataque substituem um único ataque quando você escolhe usar sua Ação para atacar",
+        "reaction": "Reação",
+        "freeAction": "Ação livre",
+        "freeActionHint": "Você pode realizar uma ação livre no seu turno sem usar uma ação ou ação bônus",
+        "longAction": "Ação longa",
+        "longActionHint": "Ações longas levam mais de um turno para serem completadas",
+        "event": "Evento",
+        "eventHint": "Eventos são ações que acontecem ao personagem como descansos ou amanhecer"
+      },
+      "attributeForm": {
+        "hitDiceSize": "Tamanho do Dado de Vida",
+        "spellSlotLevel": "Nível do espaço de magia",
+        "healthBar": "Barra de Vida",
+        "damagedColors": "Cores de Dano",
+        "half": "Metade",
+        "empty": "Vazio",
+        "damageOrder": "Ordem de dano",
+        "damageOrderHint": "Barras de vida de ordem menor receberão dano antes das de ordem maior",
+        "ignoreDamage": "Ignorar dano",
+        "preventDamageOverflow": "Prevenir excesso de dano",
+        "healingOrder": "Ordem de cura",
+        "healingOrderHint": "Barras de vida de ordem menor receberão cura antes das de ordem maior",
+        "ignoreHealing": "Ignorar cura",
+        "preventHealingOverflow": "Prevenir excesso de cura",
+        "resetHint": "Quando o dano deve ser zerado",
+        "allowDecimalValues": "Permitir valores decimais",
+        "canBeDamagedNegative": "Pode ser danificado para valores negativos",
+        "canBeIncrementedAboveTotal": "Pode ser incrementado acima do total",
+        "hideWhenTotalZero": "Ocultar quando o total for zero",
+        "hideWhenValueZero": "Ocultar quando o valor for zero",
+        "abilityScore": "Valor de habilidade",
+        "abilityScoreHint": "Valores de habilidade são seus atributos primários, como Força e Inteligência",
+        "stat": "Estatística",
+        "statHint": "Estatísticas são atributos com um valor numérico como velocidade ou capacidade de carga",
+        "modifier": "Modificador",
+        "modifierHint": "Modificadores são atributos que são adicionados a rolagens, como bônus de proficiência",
+        "hitDice": "Dados de vida",
+        "resource": "Recurso",
+        "resourceHint": "Recursos são atributos gastos para alimentar ações, como pontos de feitiçaria ou ki",
+        "spellSlot": "Espaço de magia",
+        "utility": "Utilitário",
+        "utilityHint": "Atributos utilitários não são exibidos na sua ficha de personagem, mas podem ser referenciados ou usados em cálculos"
+      },
+      "spellForm": {
+        "alwaysPrepared": "Sempre preparado",
+        "prepared": "Preparado",
+        "castWithoutSpellSlots": "Conjurar sem espaços de magia",
+        "level": "Nível",
+        "levelHint": "O nível da magia",
+        "school": "Escola",
+        "castingTime": "Tempo de Conjuração",
+        "range": "Alcance",
+        "duration": "Duração",
+        "verbal": "Verbal",
+        "somatic": "Somático",
+        "concentration": "Concentração",
+        "ritual": "Ritual",
+        "material": "Material",
+        "toHit": "Para Acertar",
+        "toHitHint": "O bônus para ataque se esta ação tiver uma rolagem de ataque",
+        "cantrip": "Truque",
+        "abjuration": "Abjuração",
+        "conjuration": "Conjuração",
+        "divination": "Adivinhação",
+        "enchantment": "Encantamento",
+        "evocation": "Evocação",
+        "illusion": "Ilusão",
+        "necromancy": "Necromancia",
+        "transmutation": "Transmutação"
+      },
+      "itemForm": {
+        "quantity": "Quantidade",
+        "pluralName": "Nome plural",
+        "pluralNameHint": "O nome plural do seu item. Se o nome do item é 'espada', o nome plural seria 'espadas'",
+        "weight": "Peso",
+        "weightHint": "O peso de um único item em libras. Pode ser um valor decimal",
+        "value": "Valor",
+        "valueHint": "O valor do item em peças de ouro, usando decimais para valores menores que 1 po",
+        "requiresAttunement": "Requer sintonização",
+        "attuned": "Sintonizado",
+        "showIncrement": "Mostrar botão de incremento",
+        "equipped": "Equipado",
+        "attunement": "Sintonização"
+      },
+      "effectForm": {
+        "operation": "Operação",
+        "value": "Valor",
+        "valueHint": "Número ou cálculo para determinar o valor deste efeito",
+        "text": "Texto",
+        "textHint": "O texto a exibir nas estatísticas afetadas",
+        "targetProperties": "Propriedades alvo",
+        "targetByVariableName": "Alvo por nome de variável",
+        "targetByTags": "Alvo por tags",
+        "stats": "Estatísticas",
+        "statsHint": "Quais estatísticas serão afetadas por este efeito",
+        "targetField": "Campo alvo",
+        "targetFieldHint": "Alvo um campo de cálculo específico nas propriedades afetadas",
+        "baseValue": "Valor Base",
+        "baseValueHint": "Estatísticas usam seu maior valor base e depois aplicam todos os outros efeitos",
+        "add": "Adicionar",
+        "addHint": "Adicionar este valor à estatística",
+        "multiply": "Multiplicar",
+        "multiplyHint": "Multiplicar a estatística por este valor",
+        "minimum": "Mínimo",
+        "minimumHint": "A estatística será pelo menos este valor",
+        "maximum": "Máximo",
+        "maximumHint": "A estatística não excederá este valor",
+        "set": "Definir",
+        "setHint": "A estatística será definida para este valor",
+        "advantage": "Vantagem",
+        "advantageHint": "Se esta estatística é a base para um teste, esse teste terá vantagem",
+        "disadvantage": "Desvantagem",
+        "disadvantageHint": "Se esta estatística é a base para um teste, esse teste terá desvantagem",
+        "passiveBonus": "Bônus Passivo",
+        "passiveBonusHint": "Este valor será adicionado ao teste passivo",
+        "fail": "Falhar",
+        "failHint": "Perícias e testes alvejados sempre falharão",
+        "conditionalBenefit": "Benefício Condicional",
+        "conditionalBenefitHint": "Adicionar uma nota de texto a esta estatística"
+      },
+      "buffForm": {
+        "appliedByTags": "Aplicado por tags",
+        "targetTags": "Tags de Alvo",
+        "targetTagsHint": "Alvo propriedades com qualquer uma das tags fornecidas",
+        "targetCreature": "Criatura alvo",
+        "actionTarget": "Alvo da Ação",
+        "self": "Próprio",
+        "children": "Filhos",
+        "hideRemoveButton": "Ocultar botão de remover",
+        "dontFreezeVariables": "Não congelar variáveis"
+      },
+      "damageForm": {
+        "damageType": "Tipo de Dano",
+        "target": "Alvo",
+        "damage": "Dano",
+        "damageHint": "Um cálculo incluindo rolagens de dados do dano a ser causado ao alvo quando ativado por uma ação",
+        "damageTypeHint": "Use o tipo Cura para restaurar pontos de vida",
+        "targetCreature": "Criatura alvo",
+        "actionTarget": "Alvo da Ação",
+        "self": "Próprio",
+        "savingThrow": "Teste de resistência",
+        "dc": "CD",
+        "dcHint": "CD do teste de resistência",
+        "save": "Resistência",
+        "saveHint": "Qual estatística o teste de resistência usa",
+        "damageOnSuccessfulSave": "Dano em resistência bem-sucedida",
+        "damageOnSuccessfulSaveHint": "Use \"~damage\" para referenciar o dano que normalmente seria causado",
+        "halfDamage": "Metade do dano"
+      },
+      "skillForm": {
+        "ability": "Habilidade",
+        "abilityHint": "Qual habilidade esta perícia é baseada",
+        "skillType": "Tipo",
+        "baseProficiency": "Proficiência Base",
+        "baseValues": "Valores Base",
+        "baseValueHint": "Este é o valor da perícia antes dos efeitos serem aplicados",
+        "applySkill": "Aplicar perícia",
+        "applySkillToTags": "Aplicar perícia a tags alvejadas",
+        "skill": "Perícia",
+        "skillHint": "Uma perícia normal da ficha de personagem como Atletismo, Enganação ou Investigação",
+        "save": "Salvaguarda",
+        "saveHint": "Uma jogada de salvaguarda que o personagem pode fazer: Salvaguarda de Força, etc.",
+        "check": "Teste",
+        "checkHint": "Um teste de habilidade que pode incluir um bônus de proficiência depois, ex. Iniciativa",
+        "tool": "Ferramenta",
+        "toolHint": "Uma proficiência de ferramenta. Certifique-se de adicionar uma proficiência base na seção avançada.",
+        "weapon": "Arma",
+        "weaponHint": "Uma proficiência de arma. Certifique-se de adicionar uma proficiência base na seção avançada.",
+        "armor": "Armadura",
+        "armorHint": "Uma proficiência de armadura. Certifique-se de adicionar uma proficiência base na seção avançada.",
+        "language": "Idioma",
+        "languageHint": "Uma proficiência de idioma. Certifique-se de adicionar uma proficiência base na seção avançada.",
+        "utility": "Utilitário",
+        "utilityHint": "Uma perícia que não aparece na ficha, mas pode ser usada por outros cálculos"
+      },
+      "proficiencyForm": {
+        "proficiencyType": "Tipo de Proficiência",
+        "optionAvailable": "Opção disponível"
+      },
+      "slotForm": {
+        "slotType": "Tipo de Slot",
+        "quantityExpected": "Quantidade Esperada",
+        "quantityExpectedHint": "Quantas propriedades devem preencher este slot",
+        "slotTags": "Tags do Slot",
+        "slotTagsHint": "Propriedades com qualquer uma destas tags podem preencher este slot",
+        "unique": "Único",
+        "uniqueHint": "Esta opção só pode ser preenchida uma vez em todo o personagem",
+        "condition": "Condição",
+        "conditionHint": "Um cálculo opcional para filtrar preenchedores de slot que podem ser aplicados",
+        "type": "Tipo",
+        "typeHint": "Qual tipo de propriedade é necessário para preencher este slot",
+        "anyType": "Qualquer tipo",
+        "quantity": "Quantidade",
+        "quantityHint": "Quantas propriedades correspondentes devem ser usadas para preencher este slot",
+        "unlimited": "ilimitado",
+        "alwaysActive": "Sempre ativo",
+        "allowDuplicates": "Permitir valores duplicados",
+        "uniqueInSlot": "Cada propriedade dentro deste slot deve ser única",
+        "uniqueInCreature": "Propriedades neste slot devem ser únicas em todo o personagem",
+        "testSlot": "Testar Slot",
+        "test": "Testar",
+        "ignored": "Ignorado"
+      },
+      "toggleForm": {
+        "enabled": "Ativado",
+        "disabled": "Desativado",
+        "showUI": "Mostrar UI",
+        "showUIHint": "Mostrar uma alternância na UI da ficha do personagem",
+        "active": "Ativo",
+        "calculated": "Calculado",
+        "condition": "Condição",
+        "conditionHint": "Quando este cálculo retornar um valor que não é falso ou zero, os filhos estarão ativos",
+        "enableOrDisable": "Ativar ou desativar propriedades",
+        "descendants": "Descendentes",
+        "byTargetTags": "Por tags de alvo",
+        "showOnCharacterSheet": "Mostrar na ficha do personagem"
+      },
+      "branchForm": {
+        "branchType": "Tipo de Ramificação",
+        "condition": "Condição",
+        "conditionHint": "Cálculo opcional para testar se esta ramificação deve ser aplicada",
+        "index": "Índice",
+        "indexHint": "Qual filho aplicar. Um índice de 2 escolherá o 2º filho.",
+        "ifConditionTrue": "Se a condição for verdadeira",
+        "attackHit": "Ataque acertou",
+        "attackMiss": "Ataque errou",
+        "saveFailed": "Resistência falhou",
+        "saveSucceeded": "Resistência bem-sucedida",
+        "applyToEachTarget": "Aplicar a cada alvo",
+        "random": "Aleatório",
+        "calculatedIndex": "Índice calculado",
+        "userChoice": "Escolha do usuário"
+      },
+      "triggerForm": {
+        "triggerEvent": "Evento Gatilho",
+        "triggerCondition": "Condição do Gatilho",
+        "actionsTaken": "Ações Realizadas",
+        "timing": "Momento",
+        "timingHint": "Quando este gatilho será acionado",
+        "event": "Evento",
+        "eventHint": "O que faz este gatilho acontecer",
+        "condition": "Condição",
+        "conditionHint": "Um cálculo para determinar se este gatilho deve ser acionado",
+        "eventType": "Tipo de Evento",
+        "eventTypeHint": "Qual evento de ação faz este gatilho ser acionado"
+      },
+      "folderForm": {
+        "grouping": "Agrupamento",
+        "groupChildrenOnCard": "Agrupar filhos em um cartão",
+        "hideChildrenFromDefault": "Ocultar filhos de seus locais padrão",
+        "tab": "Aba",
+        "location": "Localização",
+        "statsTab": "Aba de Status",
+        "featuresTab": "Aba de Habilidades",
+        "actionsTab": "Aba de Ações",
+        "spellsTab": "Aba de Feitiços",
+        "inventoryTab": "Aba de Inventário",
+        "journalTab": "Aba de Diário",
+        "buildTab": "Aba de Build",
+        "start": "Início",
+        "end": "Fim",
+        "afterEvents": "Após eventos",
+        "afterStats": "Após status",
+        "afterSkills": "Após habilidades",
+        "afterProficiencies": "Após proficiências"
+      },
+      "noteForm": {
+        "summaryHint": "Isso aparecerá no cartão na ficha do personagem",
+        "descriptionHint": "Texto que não cabe no resumo"
+      },
+      "classForm": {
+        "variableNameHint": "Use este nome em cálculos para referenciar esta classe",
+        "classLevelsFromLibraries": "Níveis de classe das bibliotecas",
+        "activeCondition": "Condição ativa",
+        "activeConditionHint": "Um cálculo para determinar se esta classe pode ter níveis de classe adicionados"
+      },
+      "featureForm": {
+        "summaryHint": "Isso aparecerá no cartão de habilidade na ficha do personagem",
+        "descriptionHint": "O resto da descrição que não cabe no resumo vai aqui"
+      },
+      "rollForm": {
+        "variableNameHint": "Use este nome em fórmulas de ação para referenciar o resultado desta rolagem",
+        "roll": "Rolagem",
+        "rollHint": "O cálculo que será avaliado quando a rolagem for acionada por uma ação. O resultado será salvo como o nome da variável no contexto da rolagem."
+      },
+      "containerForm": {
+        "value": "Valor",
+        "valueHint": "O valor do item em peças de ouro, usando decimais para valores menores que 1 po",
+        "weight": "Peso",
+        "carried": "Carregado",
+        "carriedHint": "Se este container e seu conteúdo contam para o peso carregado da criatura",
+        "contentsWeightless": "Conteúdo não tem peso"
       }
     }
   }

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -158,7 +158,12 @@
       "linkPatreonAccount": "Link Patreon Account",
       "signOut": "Sair",
       "invites": "Convites",
-      "deleteAccount": "Deletar conta"
+      "deleteAccount": "Deletar conta",
+      "language": "Idioma",
+      "languages": {
+        "en": "Inglês",
+        "pt-br": "Português (Brasil)"
+      }
     },
     "themes": {
       "dark": "Escuro",

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -305,5 +305,58 @@
     "tabletops": {
       "dontHaveAny": "Você não tem nenhuma mesa"
     }
+  },
+  "layouts": {
+    "sidebar": {
+      "signIn": "Logar",
+      "accountSettings": "Configurações da Conta",
+      "links": {
+        "home": "Início",
+        "characters": "Personagens",
+        "library": "Biblioteca",
+        "tabletops": "Mesas",
+        "friends": "Amigos",
+        "files": "Arquivos",
+        "documentation": "Documentação",
+        "feedback": "Feedback",
+        "about": "Sobre",
+        "patreon": "Patreon",
+        "github": "Github"
+      }
+    }
+  },
+  "components": {
+    "iconPicker": {
+      "searchIcons": "Buscar ícones",
+      "clear": "Limpar"
+    },
+    "treeSearch": {
+      "search": "Buscar",
+      "type": "Tipo",
+      "field": "Campo",
+      "text": "Texto",
+      "clear": "Limpar",
+      "find": "Buscar"
+    },
+    "resetSelector": {
+      "reset": "Redefinir",
+      "shortRest": "Descanso curto",
+      "longRest": "Descanso longo"
+    },
+    "colorPicker": {
+      "clear": "Limpar",
+      "done": "Concluído"
+    },
+    "propertyToolbar": {
+      "help": "Ajuda",
+      "duplicate": "Duplicar",
+      "copyTo": "Copiar Para",
+      "createReference": "Criar Referência",
+      "move": "Mover",
+      "copyToLibrary": "Copiar para biblioteca",
+      "delete": "Excluir",
+      "done": "Concluído",
+      "edit": "Editar"
+    }
   }
 }

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -325,6 +325,21 @@
       }
     }
   },
+  "dialogStack": {
+    "deleteConfirmation": {
+      "delete": "Excluir",
+      "thisCantBeUndone": "Isso não pode ser desfeito",
+      "typeToDelete": "Digite",
+      "toPermanentlyDelete": "para excluir permanentemente.",
+      "deleteForever": "Excluir permanentemente",
+      "cancel": "Cancelar"
+    },
+    "helpDialog": {
+      "title": "Ajuda:",
+      "helpDocumentNotFound": "Documentação de ajuda não encontrada para",
+      "close": "Fechar"
+    }
+  },
   "components": {
     "iconPicker": {
       "searchIcons": "Buscar ícones",
@@ -357,6 +372,205 @@
       "delete": "Excluir",
       "done": "Concluído",
       "edit": "Editar"
+    }
+  },
+  "creature": {
+    "character": {
+      "characterSheet": {
+        "notFound": "Personagem não encontrado",
+        "notFoundDescription": "Pode não existir ou você pode não ter permissão para vê-lo",
+        "stats": "Status",
+        "actions": "Ações",
+        "spells": "Feitiços",
+        "inventory": "Inventário",
+        "features": "Habilidades",
+        "journal": "Diário",
+        "build": "Build"
+      },
+      "characterCreationDialog": {
+        "title": "Novo Personagem",
+        "biography": "Biografia",
+        "libraries": "Bibliotecas",
+        "build": "Build",
+        "fields": {
+          "name": "Nome",
+          "race": "Espécie",
+          "class": "Classe",
+          "gender": "Gênero",
+          "alignment": "Alinhamento",
+          "level": "Nível"
+        },
+        "allUserLibraries": "Todas as Bibliotecas",
+        "cancel": "Cancelar",
+        "create": "Criar",
+        "back": "Voltar",
+        "next": "Próximo"
+      },
+      "characterDeleteDialog": {
+        "title": "Excluir Personagem",
+        "typeToDelete": "Digite",
+        "toPermanentlyDelete": "para excluir permanentemente o personagem",
+        "deleteForever": "Excluir permanentemente",
+        "cancel": "Cancelar"
+      },
+      "characterImportDialog": {
+        "title": "Importar Personagem",
+        "importCharacter": "Importar um personagem de outra instância do DiceCloud",
+        "importCharacterDescription": "O personagem precisa ter sua permissão de compartilhamento definida como \"qualquer um pode ver\"",
+        "import": "Importar",
+        "cancel": "Cancelar",
+        "errors": {
+          "noUserId": "Sem ID de usuário. Você está logado?",
+          "ackNoUserId": "Esta configuração de compartilhamento do personagem não permite que qualquer um veja"
+        }
+      },
+      "characterSheetToolbar": {
+        "sheetOwner": "Dono da ficha",
+        "share": "Compartilhar",
+        "unshareWithMe": "Cancelar compartilhamento comigo",
+        "print": "Imprimir",
+        "editDetails": "Editar detalhes",
+        "delete": "Excluir",
+        "tab": {
+          "stats": "Status",
+          "actions": "Ações",
+          "spells": "Feitiços",
+          "inventory": "Inventário",
+          "features": "Habilidades",
+          "journal": "Diário",
+          "build": "Build",
+          "tree": "Árvore"
+        }
+      },
+      "creatureRootDialog": {
+        "close": "Fechar"
+      },
+      "miniCharacterSheet": {
+        "characterSheet": "Ficha do personagem"
+      },
+      "characterSheetTabs": {
+        "buildTab": {
+          "hidden": "oculto",
+          "level": "Nível",
+          "milestoneLevels": "Milestone levels",
+          "gettingMissingLevels": "Obtendo Níveis Faltantes",
+          "levelUp": "Subir de Nível",
+          "slots": "Slots"
+        },
+        "inventoryTab": {
+          "weightCarried": "Peso Carregado",
+          "netWorth": "Patrimônio",
+          "itemsAttuned": "Itens Sintonizados",
+          "equipped": "Equipado",
+          "carried": "Carregado"
+        },
+        "statsTab": {
+          "buffsAndConditions": "Buffs e Condições",
+          "hitDice": "Dados de Vida",
+          "hitPoints": "Pontos de Vida",
+          "savingThrows": "Testes de Resistência",
+          "skills": "Habilidades",
+          "weapons": "Armas",
+          "armor": "Armadura",
+          "equipment": "Equipamento",
+          "tools": "Ferramentas",
+          "languages": "Idiomas"
+        }
+      },
+      "errors": {
+        "dependencyLoopError": {
+          "theCharacterContains": "O personagem contém um loop de dependência.",
+          "aSetOfPropertiesMayHaveBeenCalculatedIncorrectly": "Um conjunto de propriedades pode ter sido calculado incorretamente, porque formam um loop infinito:"
+        }
+      },
+      "printedCharacterSheet": {
+        "notFound": "Personagem não encontrado",
+        "notFoundDescription": "Pode não existir ou você pode não ter permissão para vê-lo",
+        "level": "Nível",
+        "printPrefix": "Imprimir",
+        "inventory": {
+          "title": "Inventário",
+          "weightCarried": "Peso",
+          "netWorth": "Patrimônio",
+          "itemsAttuned": "Itens Sintonizados",
+          "equipped": "Equipado",
+          "carried": "Carregando",
+          "each": "cada",
+          "lb": "lb",
+          "contents": "conteúdo",
+          "attuned": "Sintonizado",
+          "requiresAttunement": "Requer sintonização"
+        },
+        "spells": {
+          "title": "Magias"
+        },
+        "stats": {
+          "total": "Total",
+          "hitDice": "Dados de Vida",
+          "savingThrows": "Testes de Resistência",
+          "skills": "Habilidades",
+          "weapons": "Armas",
+          "armor": "Armadura",
+          "tools": "Ferramentas",
+          "languages": "Idiomas",
+          "proficiencies": "Proficiências",
+          "spellSlots": "Espaços de Magia",
+          "shield": "Escudo"
+        },
+        "actions": {
+          "uses": "usos",
+          "cost": "Custo",
+          "usesCap": "Usos",
+          "toHit": "para acertar",
+          "types": {
+            "action": "Ação",
+            "bonus": "Ação Bônus",
+            "attack": "Ataque",
+            "reaction": "Reação",
+            "free": "Ação Livre",
+            "long": "Ação Longa"
+          }
+        },
+        "damageMultipliers": {
+          "immunity": "Imunidade",
+          "resistance": "Resistência",
+          "vulnerability": "Vulnerabilidade",
+          "for": "Para",
+          "except": "Exceto"
+        },
+        "skill": {
+          "fail": "falha"
+        },
+        "spell": {
+          "level": {
+            "cantrip": "truque",
+            "0": "truque",
+            "1": "1º nível",
+            "2": "2º nível",
+            "3": "3º nível",
+            "4": "4º nível",
+            "5": "5º nível",
+            "6": "6º nível",
+            "7": "7º nível",
+            "8": "8º nível",
+            "9": "9º nível",
+            "generic": "{level}º nível"
+          },
+          "ritual": "(ritual)",
+          "toHit": "Para acertar",
+          "castingTime": "Tempo de execução",
+          "range": "Alcance",
+          "components": "Componentes",
+          "duration": "Duração"
+        },
+        "spellList": {
+          "saveDc": "CD de Resistência de Magia",
+          "ability": "Habilidade de conjuração",
+          "abilityMod": "Modificador de habilidade de conjuração",
+          "attackBonus": "Bônus de Ataque de Magia",
+          "maxPrepared": "Máximo de magias preparadas"
+        }
+      }
     }
   }
 }

--- a/app/imports/client/ui/locales/pt-BR.json
+++ b/app/imports/client/ui/locales/pt-BR.json
@@ -571,6 +571,45 @@
           "maxPrepared": "Máximo de magias preparadas"
         }
       }
+    },
+    "actions": {
+      "done": "Confirmar",
+      "input": {
+        "advantageInput": {
+          "disadvantage": "Desvantagem",
+          "advantage": "Vantagem",
+          "roll": "Rodar"
+        },
+        "castSpellInput": {
+          "clear": "Limpar",
+          "done": "Confirmar",
+          "slot": "Slot",
+          "castWithoutSpellSlot": "Sem slot de magia",
+          "castAsRitual": "Como ritual",
+          "spell": "Magia",
+          "cantrip": "Truque",
+          "level": "Nível"
+        },
+        "checkInput": {
+          "roll": "Rodar",
+          "advantage": "Vantagem",
+          "disadvantage": "Desvantagem",
+          "select": {
+            "ability": "Habilidade",
+            "skill": "Proficiência"
+          },
+          "dc": "CD"
+        },
+        "choiceInput": {
+          "done": "Confirmar"
+        },
+        "targetsInput": {
+          "singleTarget": "Alvo",
+          "multipleTargets": "Alvos",
+          "noTarget": "Sem alvo",
+          "continue": "Continuar"
+        }
+      }
     }
   }
 }

--- a/app/imports/client/ui/pages/About.vue
+++ b/app/imports/client/ui/pages/About.vue
@@ -15,7 +15,7 @@
             class="white--text ma-2 text-center"
             style="max-width: 1200px;"
           >
-            {{ $t('about.description') }}
+            {{ $t('pages.about.description') }}
           </p>
         </v-layout>
       </v-parallax>
@@ -23,12 +23,12 @@
     <section class="layout column align-center ma-2 mt-4">
       <div>
         <h3 class="text-h5 mb-2">
-          {{ $t('about.specialThanks') }}
+          {{ $t('pages.about.specialThanks') }}
         </h3>
         <p>
-          <b>Sam;</b> {{ $t('about.sam') }}
+          <b>Sam;</b> {{ $t('pages.about.sam') }}
         </p><p>
-          <b>The "Heroes" of Asaea</b> {{ $t('about.heroes') }}
+          <b>The "Heroes" of Asaea</b> {{ $t('pages.about.heroes') }}
         </p>
         <h3 class="text-h6">
           Paragon tier Patrons

--- a/app/imports/client/ui/pages/About.vue
+++ b/app/imports/client/ui/pages/About.vue
@@ -15,10 +15,7 @@
             class="white--text ma-2 text-center"
             style="max-width: 1200px;"
           >
-            DiceCloud is a single-developer project started in 2014 with the aim of
-            being a character sheet that stayed in sync between the DM and their
-            players, and made it clear where every value in the sheet came from, and
-            how it was calculated.
+            {{ $t('about.description') }}
           </p>
         </v-layout>
       </v-parallax>
@@ -26,13 +23,12 @@
     <section class="layout column align-center ma-2 mt-4">
       <div>
         <h3 class="text-h5 mb-2">
-          Special Thanks
+          {{ $t('about.specialThanks') }}
         </h3>
         <p>
-          <b>Sam;</b> without her love, DiceCloud could not hope to exist
+          <b>Sam;</b> {{ $t('about.sam') }}
         </p><p>
-          <b>The "Heroes" of Asaea</b> The D&amp;D party whose joy was the fuel
-          powering the early versions of DiceCloud.
+          <b>The "Heroes" of Asaea</b> {{ $t('about.heroes') }}
         </p>
         <h3 class="text-h6">
           Paragon tier Patrons

--- a/app/imports/client/ui/pages/Account.vue
+++ b/app/imports/client/ui/pages/Account.vue
@@ -9,11 +9,11 @@
     >
       <v-list>
         <v-subheader>
-          {{ $t('account.fileStorageUsed') }}
+          {{ $t('pages.account.fileStorageUsed') }}
         </v-subheader>
         <file-storage-stats />
         <v-subheader>
-          {{ $t('account.characterStorageUsed') }}
+          {{ $t('pages.account.characterStorageUsed') }}
         </v-subheader>
         <v-list-item>
           <v-list-item-title>
@@ -21,23 +21,23 @@
           </v-list-item-title>
         </v-list-item>
         <v-subheader class="mb-4">
-          {{ $t('account.preferences') }}
+          {{ $t('pages.account.preferences') }}
         </v-subheader>
         <v-list-item>
           <smart-toggle
             label="Theme"
             :value="darkMode === true ? 'true' : darkMode === false ? 'false' : darkMode === null ? 'unset': undefined"
             :options="[
-              {name: $t('themes.dark'), value: 'true', icon: 'mdi-brightness-5'},
-              {name: $t('themes.matchDeviceTheme'), value: 'unset'},
-              {name: $t('themes.light'), value: 'false', icon: 'mdi-brightness-7'},
+              {name: $t('pages.themes.dark'), value: 'true', icon: 'mdi-brightness-5'},
+              {name: $t('pages.themes.matchDeviceTheme'), value: 'unset'},
+              {name: $t('pages.themes.light'), value: 'false', icon: 'mdi-brightness-7'},
             ]"
             @change="setDarkMode"
           />
         </v-list-item>
         <v-list-item>
           <smart-switch
-            :label="$t('account.swapAbilityScoresAndModifiers')"
+            :label="$t('pages.account.swapAbilityScoresAndModifiers')"
             :value="
               user &&
                 user.preferences &&
@@ -48,7 +48,7 @@
         </v-list-item>
 
         <v-subheader>
-          {{ $t('account.username') }}
+          {{ $t('pages.account.username') }}
         </v-subheader>
         <v-list-item data-id="username">
           <v-list-item-action>
@@ -62,7 +62,7 @@
                   <v-icon>mdi-pencil</v-icon>
                 </v-btn>
               </template>
-              <span>{{ $t('account.changeUsername') }}</span>
+              <span>{{ $t('pages.account.changeUsername') }}</span>
             </v-tooltip>
           </v-list-item-action>
           <v-list-item-title>
@@ -71,7 +71,7 @@
         </v-list-item>
 
         <v-subheader>
-          {{ $t('account.email') }}
+          {{ $t('pages.account.email') }}
         </v-subheader>
         <v-list-item
           v-for="email in emails"
@@ -147,7 +147,7 @@
                   <v-icon>mdi-refresh</v-icon>
                 </v-btn>
               </template>
-              <span>{{ $t('account.refreshPatreonStatus') }}</span>
+              <span>{{ $t('pages.account.refreshPatreonStatus') }}</span>
             </v-tooltip>
           </v-list-item-action>
           <v-list-item-title>
@@ -159,7 +159,7 @@
             color="primary"
             @click="linkWithGoogle"
           >
-            {{ $t('account.linkGoogleAccount') }}
+            {{ $t('pages.account.linkGoogleAccount') }}
           </v-btn>
         </v-list-item>
         <v-list-item v-if="!user.services.patreon">
@@ -167,7 +167,7 @@
             color="primary"
             @click="linkWithPatreon"
           >
-            {{ $t('account.linkPatreonAccount') }}
+            {{ $t('pages.account.linkPatreonAccount') }}
           </v-btn>
         </v-list-item>
       </v-list>
@@ -178,14 +178,14 @@
           color="accent"
           @click="signOut"
         >
-          {{ $t('account.signOut') }}
+          {{ $t('pages.account.signOut') }}
         </v-btn>
       </v-layout>
       <template v-if="invites.length">
         <v-divider class="mt-3 mb-3" />
         <v-subheader>
           <h1>
-            {{ $t('account.invites') }}
+            {{ $t('pages.account.invites') }}
           </h1>
         </v-subheader>
         <v-list>
@@ -221,7 +221,7 @@
           data-id="delete-account-btn"
           @click="deleteAccount"
         >
-          {{ $t('account.deleteAccount') }}
+          {{ $t('pages.account.deleteAccount') }}
         </v-btn>
       </v-layout>
     </v-card>

--- a/app/imports/client/ui/pages/Account.vue
+++ b/app/imports/client/ui/pages/Account.vue
@@ -9,11 +9,11 @@
     >
       <v-list>
         <v-subheader>
-          File storage used
+          {{ $t('account.fileStorageUsed') }}
         </v-subheader>
         <file-storage-stats />
         <v-subheader>
-          Character storage used
+          {{ $t('account.characterStorageUsed') }}
         </v-subheader>
         <v-list-item>
           <v-list-item-title>
@@ -21,23 +21,23 @@
           </v-list-item-title>
         </v-list-item>
         <v-subheader class="mb-4">
-          Preferences
+          {{ $t('account.preferences') }}
         </v-subheader>
         <v-list-item>
           <smart-toggle
             label="Theme"
             :value="darkMode === true ? 'true' : darkMode === false ? 'false' : darkMode === null ? 'unset': undefined"
             :options="[
-              {name: 'Dark', value: 'true', icon: 'mdi-brightness-5'},
-              {name: 'Match device theme', value: 'unset'},
-              {name: 'Light', value: 'false', icon: 'mdi-brightness-7'},
+              {name: $t('themes.dark'), value: 'true', icon: 'mdi-brightness-5'},
+              {name: $t('themes.matchDeviceTheme'), value: 'unset'},
+              {name: $t('themes.light'), value: 'false', icon: 'mdi-brightness-7'},
             ]"
             @change="setDarkMode"
           />
         </v-list-item>
         <v-list-item>
           <smart-switch
-            label="Swap ability scores and modifiers"
+            :label="$t('account.swapAbilityScoresAndModifiers')"
             :value="
               user &&
                 user.preferences &&
@@ -48,7 +48,7 @@
         </v-list-item>
 
         <v-subheader>
-          Username
+          {{ $t('account.username') }}
         </v-subheader>
         <v-list-item data-id="username">
           <v-list-item-action>
@@ -62,7 +62,7 @@
                   <v-icon>mdi-pencil</v-icon>
                 </v-btn>
               </template>
-              <span>Change Username</span>
+              <span>{{ $t('account.changeUsername') }}</span>
             </v-tooltip>
           </v-list-item-action>
           <v-list-item-title>
@@ -71,7 +71,7 @@
         </v-list-item>
 
         <v-subheader>
-          Email
+          {{ $t('account.email') }}
         </v-subheader>
         <v-list-item
           v-for="email in emails"
@@ -147,7 +147,7 @@
                   <v-icon>mdi-refresh</v-icon>
                 </v-btn>
               </template>
-              <span>Refresh Patreon status</span>
+              <span>{{ $t('account.refreshPatreonStatus') }}</span>
             </v-tooltip>
           </v-list-item-action>
           <v-list-item-title>
@@ -159,7 +159,7 @@
             color="primary"
             @click="linkWithGoogle"
           >
-            Link Google Account
+            {{ $t('account.linkGoogleAccount') }}
           </v-btn>
         </v-list-item>
         <v-list-item v-if="!user.services.patreon">
@@ -167,7 +167,7 @@
             color="primary"
             @click="linkWithPatreon"
           >
-            Link Patreon Account
+            {{ $t('account.linkPatreonAccount') }}
           </v-btn>
         </v-list-item>
       </v-list>
@@ -178,14 +178,14 @@
           color="accent"
           @click="signOut"
         >
-          Sign Out
+          {{ $t('account.signOut') }}
         </v-btn>
       </v-layout>
       <template v-if="invites.length">
         <v-divider class="mt-3 mb-3" />
         <v-subheader>
           <h1>
-            Invites
+            {{ $t('account.invites') }}
           </h1>
         </v-subheader>
         <v-list>
@@ -221,7 +221,7 @@
           data-id="delete-account-btn"
           @click="deleteAccount"
         >
-          Delete Account
+          {{ $t('account.deleteAccount') }}
         </v-btn>
       </v-layout>
     </v-card>

--- a/app/imports/client/ui/pages/Account.vue
+++ b/app/imports/client/ui/pages/Account.vue
@@ -36,6 +36,17 @@
           />
         </v-list-item>
         <v-list-item>
+          <smart-toggle
+            :label="$t('pages.account.language')"
+            :value="language"
+            :options="[
+              {name: $t('pages.account.languages.en'), value: 'en', icon: '🇺🇸'},
+              {name: $t('pages.account.languages.pt-br'), value: 'pt-br', icon: '🇧🇷'},
+            ]"
+            @change="setLanguage"
+          />
+        </v-list-item>
+        <v-list-item>
           <smart-switch
             :label="$t('pages.account.swapAbilityScoresAndModifiers')"
             :value="
@@ -238,6 +249,7 @@
   import removeEmail from '/imports/api/users/methods/removeEmail';
   import CreatureStorageStats from '/imports/client/ui/creature/creatureList/CreatureStorageStats.vue';
   import FileStorageStats from '/imports/client/ui/files/FileStorageStats.vue';
+  import i18n from '/imports/client/ui/i18n';
 
   export default {
     components: {
@@ -264,6 +276,9 @@
       },
       darkMode(){
         return this.user && this.user.darkMode;
+      },
+      language(){
+        return this.user && this.user.language || 'en';
       },
       invites(){
         let usernames = {};
@@ -355,6 +370,13 @@
           darkMode = null;
         }
         Meteor.users.setDarkMode.call({darkMode}, ack);
+      },
+      setLanguage(value, ack){
+        // Map 'pt-br' to 'pt-BR' for i18n locale
+        const i18nLocale = value === 'pt-br' ? 'pt-BR' : value;
+        i18n.locale = i18nLocale;
+        localStorage.setItem('locale', i18nLocale);
+        Meteor.users.setLanguage.call({language: value}, ack);
       },
       swapAbilityScoresAndModifiers(value, ack){
         Meteor.users.setPreference.call({

--- a/app/imports/client/ui/pages/Admin.vue
+++ b/app/imports/client/ui/pages/Admin.vue
@@ -4,14 +4,14 @@
       <v-col cols="12">
         <v-card>
           <v-card-text>
-            <h4>Current database version: {{ versions && versions.dbVersion }}</h4>
+            <h4>{{ $t("pages.admin.currentDatabaseVersion") }} {{ versions && versions.dbVersion }}</h4>
             <h4 v-if="schemaVersion == versions.dbVersion ">
-              Database is up to date with latest version. Restart to enable navigation.
+              {{ $t("pages.admin.databaseIsUpToDate") }}
             </h4>
             <h4 v-else>
-              Expected database version: {{ schemaVersion }}
+              {{ $t("pages.admin.expectedDatabaseVersion") }} {{ schemaVersion }}
             </h4>
-            <h4>Git version: {{ versions && versions.gitVersion }}</h4>
+            <h4>{{ $t("pages.admin.gitVersion") }} {{ versions && versions.gitVersion }}</h4>
             <v-alert
               v-if="versionError"
               type="error"
@@ -29,15 +29,14 @@
               type="warning"
               outlined
             >
-              Back up the database before attempting any migration. A failed
-              migration can result in profound data loss.
+              {{ $t("pages.admin.backUpTheDatabase") }}
             </v-alert>
             <v-btn
               :disabled="!(schemaVersion > (versions && versions.dbVersion))"
               :loading="loadingMigration"
               @click="migrate"
             >
-              Migrate to database version {{ schemaVersion }}
+              {{ $t("pages.admin.migrateTo") }} {{ schemaVersion }}
             </v-btn>
             <v-alert
               v-if="migrateError"

--- a/app/imports/client/ui/pages/CharacterList.vue
+++ b/app/imports/client/ui/pages/CharacterList.vue
@@ -16,19 +16,19 @@
             v-if="characterSpaceLeft < 0"
             type="error"
           >
-            {{ $t('characterList.alert.exceededLimit') }}
+            {{ $t('pages.characterList.alert.exceededLimit') }}
           </v-alert>
           <v-alert
             v-else-if="characterSpaceLeft === 0"
             type="info"
           >
-            {{ $t('characterList.alert.limit') }}
+            {{ $t('pages.characterList.alert.limit') }}
             <archive-button
               small
               text
               class="mx-2"
             />
-            {{ $t('characterList.alert.or') }}
+            {{ $t('pages.characterList.alert.or') }}
             <v-btn
               href="https://www.patreon.com/join/dicecloud/"
               class="mx-2"
@@ -36,7 +36,7 @@
               small
               text
             >
-              {{ $t('characterList.alert.increasePatreon') }}
+              {{ $t('pages.characterList.alert.increasePatreon') }}
               <v-icon right>
                 mdi-patreon
               </v-icon>
@@ -55,14 +55,14 @@
               data-id="import-character-button"
               @click="importCharacter"
             >
-              {{ $t('characterList.importCharacter') }}
+              {{ $t('pages.characterList.importCharacter') }}
             </v-btn>
             <v-btn
               text
               :loading="loadingInsertFolder"
               @click="insertFolder"
             >
-              {{ $t('characterList.addFolder') }}
+              {{ $t('pages.characterList.addFolder') }}
             </v-btn>
           </div>
           <v-btn

--- a/app/imports/client/ui/pages/CharacterList.vue
+++ b/app/imports/client/ui/pages/CharacterList.vue
@@ -16,20 +16,19 @@
             v-if="characterSpaceLeft < 0"
             type="error"
           >
-            You have exceeded your maximum number of character slots, archive or delete
-            some characters.
+            {{ $t('characterList.alert.exceededLimit') }}
           </v-alert>
           <v-alert
             v-else-if="characterSpaceLeft === 0"
             type="info"
           >
-            You have hit your maximum number of characters.
+            {{ $t('characterList.alert.limit') }}
             <archive-button
               small
               text
               class="mx-2"
             />
-            or
+            {{ $t('characterList.alert.or') }}
             <v-btn
               href="https://www.patreon.com/join/dicecloud/"
               class="mx-2"
@@ -37,7 +36,7 @@
               small
               text
             >
-              Increase Patreon tier
+              {{ $t('characterList.alert.increasePatreon') }}
               <v-icon right>
                 mdi-patreon
               </v-icon>
@@ -56,14 +55,14 @@
               data-id="import-character-button"
               @click="importCharacter"
             >
-              import character
+              {{ $t('characterList.importCharacter') }}
             </v-btn>
             <v-btn
               text
               :loading="loadingInsertFolder"
               @click="insertFolder"
             >
-              add folder
+              {{ $t('characterList.addFolder') }}
             </v-btn>
           </div>
           <v-btn

--- a/app/imports/client/ui/pages/DocsPage.vue
+++ b/app/imports/client/ui/pages/DocsPage.vue
@@ -27,7 +27,7 @@
           cols="12"
           md="8"
         >
-          <h1>Documentation not found</h1>
+          <h1>{{ $t('docsPage.notFound') }}</h1>
         </v-col>
       </v-row>
       <doc-edit-form

--- a/app/imports/client/ui/pages/DocsPage.vue
+++ b/app/imports/client/ui/pages/DocsPage.vue
@@ -27,7 +27,7 @@
           cols="12"
           md="8"
         >
-          <h1>{{ $t('docsPage.notFound') }}</h1>
+          <h1>{{ $t('pages.docsPage.notFound') }}</h1>
         </v-col>
       </v-row>
       <doc-edit-form

--- a/app/imports/client/ui/pages/Documentation.vue
+++ b/app/imports/client/ui/pages/Documentation.vue
@@ -25,7 +25,7 @@
           />
           <v-card v-else-if="!doc">
             <v-card-title>
-              {{ $t('documentation.notFound') }} {{ title }}
+              {{ $t('pages.documentation.notFound') }} {{ title }}
             </v-card-title>
           </v-card>
         </v-fade-transition>

--- a/app/imports/client/ui/pages/Documentation.vue
+++ b/app/imports/client/ui/pages/Documentation.vue
@@ -25,7 +25,7 @@
           />
           <v-card v-else-if="!doc">
             <v-card-title>
-              Help document not found for {{ title }}
+              {{ $t('documentation.notFound') }} {{ title }}
             </v-card-title>
           </v-card>
         </v-fade-transition>

--- a/app/imports/client/ui/pages/EmailVerificationError.vue
+++ b/app/imports/client/ui/pages/EmailVerificationError.vue
@@ -6,7 +6,7 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        {{ $t('emailVerificationError.title') }}
+        {{ $t('pages.emailVerificationError.title') }}
       </h2>
       <h3>
         {{ error.reason || error.message || error }}

--- a/app/imports/client/ui/pages/EmailVerificationError.vue
+++ b/app/imports/client/ui/pages/EmailVerificationError.vue
@@ -6,7 +6,7 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        Email Verification Error
+        {{ $t('emailVerificationError.title') }}
       </h2>
       <h3>
         {{ error.reason || error.message || error }}

--- a/app/imports/client/ui/pages/EmailVerificationSuccess.vue
+++ b/app/imports/client/ui/pages/EmailVerificationSuccess.vue
@@ -6,10 +6,10 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        {{ $t('emailVerificationSuccess.title') }}
+        {{ $t('pages.emailVerificationSuccess.title') }}
       </h2>
       <h3>
-        {{ $t('emailVerificationSuccess.subtitle') }}
+        {{ $t('pages.emailVerificationSuccess.subtitle') }}
       </h3>
     </v-layout>
   </div>

--- a/app/imports/client/ui/pages/EmailVerificationSuccess.vue
+++ b/app/imports/client/ui/pages/EmailVerificationSuccess.vue
@@ -6,10 +6,10 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        Email Verified
+        {{ $t('emailVerificationSuccess.title') }}
       </h2>
       <h3>
-        Your email address has been verified
+        {{ $t('emailVerificationSuccess.subtitle') }}
       </h3>
     </v-layout>
   </div>

--- a/app/imports/client/ui/pages/Feedback.vue
+++ b/app/imports/client/ui/pages/Feedback.vue
@@ -13,11 +13,10 @@
       <v-card-title primary-title>
         <div>
           <h3 class="text-h5 mb-0">
-            DiceCloud Discord server
+            {{ $t('feedback.discordServer') }}
           </h3>
           <div>
-            To give feedback or get support using DiceCloud,
-            join the official Discord server
+            {{ $t('feedback.discordDescriptionServer') }}
           </div>
         </div>
       </v-card-title>
@@ -28,7 +27,7 @@
           color="primary"
           href="https://discord.gg/qEvdfeB"
         >
-          Join
+          {{ $t('feedback.join') }}
         </v-btn>
       </v-card-actions>
     </v-card>

--- a/app/imports/client/ui/pages/Feedback.vue
+++ b/app/imports/client/ui/pages/Feedback.vue
@@ -13,10 +13,10 @@
       <v-card-title primary-title>
         <div>
           <h3 class="text-h5 mb-0">
-            {{ $t('feedback.discordServer') }}
+            {{ $t('pages.feedback.discordServer') }}
           </h3>
           <div>
-            {{ $t('feedback.discordDescriptionServer') }}
+            {{ $t('pages.feedback.discordDescriptionServer') }}
           </div>
         </div>
       </v-card-title>
@@ -27,7 +27,7 @@
           color="primary"
           href="https://discord.gg/qEvdfeB"
         >
-          {{ $t('feedback.join') }}
+          {{ $t('pages.feedback.join') }}
         </v-btn>
       </v-card-actions>
     </v-card>

--- a/app/imports/client/ui/pages/Files.vue
+++ b/app/imports/client/ui/pages/Files.vue
@@ -8,7 +8,7 @@
     </v-row>
     <v-row dense>
       <v-col cols="12">
-        <v-subheader> {{ $t('filePage.archivedChar') }} </v-subheader>
+        <v-subheader> {{ $t('pages.filePage.archivedChar') }} </v-subheader>
       </v-col>
       
       <v-col
@@ -42,7 +42,7 @@
             {{ archiveFileError }}
           </template>
           <template v-else>
-            {{ $t('filePage.uploadArchive') }}
+            {{ $t('pages.filePage.uploadArchive') }}
           </template>
           <v-progress-linear
             v-if="archiveUploadInProgress"
@@ -67,7 +67,7 @@
     </v-row>
     <v-row dense>
       <v-col cols="12">
-        <v-subheader> {{ $t('filePage.images') }} </v-subheader>
+        <v-subheader> {{ $t('pages.filePage.images') }} </v-subheader>
       </v-col>
       <v-col
         cols="12"
@@ -219,11 +219,11 @@ export default {
       this.$refs.archiveFileInput.value = null;
       if (!file) return;
       if (file.type !== 'application/json'){
-        this.archiveFileError = this.$t('filePage.errors.mustBeJson');
+        this.archiveFileError = this.$t('pages.filePage.errors.mustBeJson');
         return;
       }
       if (file.size > 10000000){
-        this.archiveFileError = this.$t('filePage.errors.fileTooLarge');
+        this.archiveFileError = this.$t('pages.filePage.errors.fileTooLarge');
         return;
       }
       this.archiveFile = file;
@@ -239,7 +239,7 @@ export default {
         try {
           data = JSON.parse(fr.result);
         } catch (e){
-          self.archiveFileError = this.$t('filePage.errors.fileCouldntBeParsed');
+          self.archiveFileError = this.$t('pages.filePage.errors.fileCouldntBeParsed');
           self.archiveUploadInProgress = false;
           console.error(e);
           return;
@@ -250,7 +250,7 @@ export default {
           data = archiveSchema.clean(data);
           archiveSchema.validate(data);
         } catch (e){
-          self.archiveFileError = this.$t('filePage.errors.fileFailedValidation') + (e.reason || e.message || e.toString());
+          self.archiveFileError = this.$t('pages.filePage.errors.fileFailedValidation') + (e.reason || e.message || e.toString());
           self.archiveUploadInProgress = false;
           console.error(e);
           return;

--- a/app/imports/client/ui/pages/Files.vue
+++ b/app/imports/client/ui/pages/Files.vue
@@ -8,7 +8,7 @@
     </v-row>
     <v-row dense>
       <v-col cols="12">
-        <v-subheader> Archived Characters </v-subheader>
+        <v-subheader> {{ $t('filePage.archivedChar') }} </v-subheader>
       </v-col>
       
       <v-col
@@ -42,7 +42,7 @@
             {{ archiveFileError }}
           </template>
           <template v-else>
-            Upload archive
+            {{ $t('filePage.uploadArchive') }}
           </template>
           <v-progress-linear
             v-if="archiveUploadInProgress"
@@ -67,7 +67,7 @@
     </v-row>
     <v-row dense>
       <v-col cols="12">
-        <v-subheader> Images </v-subheader>
+        <v-subheader> {{ $t('filePage.images') }} </v-subheader>
       </v-col>
       <v-col
         cols="12"
@@ -219,11 +219,11 @@ export default {
       this.$refs.archiveFileInput.value = null;
       if (!file) return;
       if (file.type !== 'application/json'){
-        this.archiveFileError = 'File must be .json';
+        this.archiveFileError = this.$t('filePage.errors.mustBeJson');
         return;
       }
       if (file.size > 10000000){
-        this.archiveFileError = 'File too large';
+        this.archiveFileError = this.$t('filePage.errors.fileTooLarge');
         return;
       }
       this.archiveFile = file;
@@ -239,7 +239,7 @@ export default {
         try {
           data = JSON.parse(fr.result);
         } catch (e){
-          self.archiveFileError = 'File could not be parsed';
+          self.archiveFileError = this.$t('filePage.errors.fileCouldntBeParsed');
           self.archiveUploadInProgress = false;
           console.error(e);
           return;
@@ -250,7 +250,7 @@ export default {
           data = archiveSchema.clean(data);
           archiveSchema.validate(data);
         } catch (e){
-          self.archiveFileError = 'File failed validation: ' + (e.reason || e.message || e.toString());
+          self.archiveFileError = this.$t('filePage.errors.fileFailedValidation') + (e.reason || e.message || e.toString());
           self.archiveUploadInProgress = false;
           console.error(e);
           return;

--- a/app/imports/client/ui/pages/Friends.vue
+++ b/app/imports/client/ui/pages/Friends.vue
@@ -2,7 +2,7 @@
   <div>
     <v-sheet>
       <h1>
-        Friends
+        {{ $t("pages.friends.title") }}
       </h1>
       <v-btn
         fixed

--- a/app/imports/client/ui/pages/FunctionReference.vue
+++ b/app/imports/client/ui/pages/FunctionReference.vue
@@ -7,7 +7,7 @@
       >
         <v-card>
           <v-card-text class="markdown">
-            <h1>Functions</h1>
+            <h1>{{ $t("pages.functionReference.title") }}</h1>
             <div
               v-for="fn in functions"
               :key="fn.name"

--- a/app/imports/client/ui/pages/Home.vue
+++ b/app/imports/client/ui/pages/Home.vue
@@ -16,10 +16,10 @@
           cols="12"
         >
           <h1 class="text-h4 mb-4">
-            Free, Auditable, real-time character tracking for 5th edition
+            {{ $t('home.title') }}
           </h1>
           <h4 class="subheading">
-            Spend less time shuffling paper, and more time playing the game
+            {{ $t('home.subtitle') }}
           </h4>
         </v-col>
       </v-row>
@@ -35,7 +35,7 @@
           to="/register"
           class="mr-4"
         >
-          Register
+          {{ $t('home.register') }}
         </v-btn>
         <v-btn
           color="accent"
@@ -44,7 +44,7 @@
           large
           to="/sign-in"
         >
-          Sign In
+          {{ $t('home.signIn') }}
         </v-btn>
       </v-layout>
       <v-layout
@@ -59,7 +59,7 @@
           to="/character-list"
           class="mr-4"
         >
-          My Characters
+          {{ $t('home.myCharacters') }}
         </v-btn>
       </v-layout>
     </section>
@@ -86,11 +86,10 @@
             mdi-currency-usd-off
           </v-icon>
           <h3 class="mb-2">
-            Free, open source, community funded
+            {{ $t('home.freeOpen') }}
           </h3>
           <p>
-            DiceCloud is free to use, funded via Patreon,
-            and the source code is available on Github under a GPL license.
+            {{ $t('home.freeOpenDescription') }}
           </p>
         </v-layout>
         <v-layout
@@ -104,11 +103,10 @@
             mdi-ballot-outline
           </v-icon>
           <h3 class="mb-2">
-            Custom everything
+            {{ $t('home.customEverything') }}
           </h3>
           <p>
-            Add new ability scores, skills, health-bars, and stats to your character.
-            The entire sheet is under your control.
+            {{ $t('home.customEverythingDescription') }}
           </p>
         </v-layout>
         <v-layout
@@ -122,11 +120,10 @@
             mdi-file-tree-outline
           </v-icon>
           <h3 class="mb-2">
-            Advanced Character Engine
+            {{ $t('home.advancedCharacters') }}
           </h3>
           <p>
-            Characters are computed in real-time based on their equipment,
-            features, and buffs.
+            {{ $t('home.advancedCharactersDescription') }}
           </p>
         </v-layout>
       </v-layout>
@@ -156,7 +153,7 @@
     </section>
     <section class="text-center grey darken-3 white--text pa-5">
       <h1>
-        Get involved in the DiceCloud community
+        {{ $t('home.getInvolved') }}
       </h1>
       <v-layout
         wrap
@@ -198,15 +195,16 @@ export default {
       lg: 3,
       xl: 2,
     },
+    // TODO: The translation doesn't work here
     highlightCards: [
-      { text: 'Automated actions', img: 'actions.webp' },
-      { text: 'Auditable stats', img: 'auditable.webp' },
-      { text: 'Dice rolling', img: 'automated-dice-rolls.webp' },
-      { text: 'Hackable character builder', img: 'build-system.webp' },
-      { text: 'Drag and drop inventory manager', img: 'inventory.webp' },
-      { text: 'Custom libraries of content', img: 'libraries-of-content.webp' },
-      { text: 'Discord webhooks', img: 'send-to-discord.webp' },
-      { text: 'Printed character sheets', img: 'printing.webp' },
+      { text: this.$t('home.highlightCards.automatedActions'), img: 'actions.webp' },
+      { text: this.$t('home.highlightCards.auditableStats'), img: 'auditable.webp' },
+      { text: this.$t('home.highlightCards.diceRolling'), img: 'automated-dice-rolls.webp' },
+      { text: this.$t('home.highlightCards.hackableChar'), img: 'build-system.webp' },
+      { text: this.$t('home.highlightCards.dragAndDrop'), img: 'inventory.webp' },
+      { text: this.$t('home.highlightCards.customLibraries'), img: 'libraries-of-content.webp' },
+      { text: this.$t('home.highlightCards.discordWebhooks'), img: 'send-to-discord.webp' },
+      { text: this.$t('home.highlightCards.printedCharacters'), img: 'printing.webp' },
     ],
   }},
   meteor: {

--- a/app/imports/client/ui/pages/Home.vue
+++ b/app/imports/client/ui/pages/Home.vue
@@ -16,10 +16,10 @@
           cols="12"
         >
           <h1 class="text-h4 mb-4">
-            {{ $t('home.title') }}
+            {{ $t('pages.home.title') }}
           </h1>
           <h4 class="subheading">
-            {{ $t('home.subtitle') }}
+            {{ $t('pages.home.subtitle') }}
           </h4>
         </v-col>
       </v-row>
@@ -35,7 +35,7 @@
           to="/register"
           class="mr-4"
         >
-          {{ $t('home.register') }}
+          {{ $t('pages.home.register') }}
         </v-btn>
         <v-btn
           color="accent"
@@ -44,7 +44,7 @@
           large
           to="/sign-in"
         >
-          {{ $t('home.signIn') }}
+          {{ $t('pages.home.signIn') }}
         </v-btn>
       </v-layout>
       <v-layout
@@ -59,7 +59,7 @@
           to="/character-list"
           class="mr-4"
         >
-          {{ $t('home.myCharacters') }}
+          {{ $t('pages.home.myCharacters') }}
         </v-btn>
       </v-layout>
     </section>
@@ -86,10 +86,10 @@
             mdi-currency-usd-off
           </v-icon>
           <h3 class="mb-2">
-            {{ $t('home.freeOpen') }}
+            {{ $t('pages.home.freeOpen') }}
           </h3>
           <p>
-            {{ $t('home.freeOpenDescription') }}
+            {{ $t('pages.home.freeOpenDescription') }}
           </p>
         </v-layout>
         <v-layout
@@ -103,10 +103,10 @@
             mdi-ballot-outline
           </v-icon>
           <h3 class="mb-2">
-            {{ $t('home.customEverything') }}
+            {{ $t('pages.home.customEverything') }}
           </h3>
           <p>
-            {{ $t('home.customEverythingDescription') }}
+            {{ $t('pages.home.customEverythingDescription') }}
           </p>
         </v-layout>
         <v-layout
@@ -120,10 +120,10 @@
             mdi-file-tree-outline
           </v-icon>
           <h3 class="mb-2">
-            {{ $t('home.advancedCharacters') }}
+            {{ $t('pages.home.advancedCharacters') }}
           </h3>
           <p>
-            {{ $t('home.advancedCharactersDescription') }}
+            {{ $t('pages.home.advancedCharactersDescription') }}
           </p>
         </v-layout>
       </v-layout>
@@ -153,7 +153,7 @@
     </section>
     <section class="text-center grey darken-3 white--text pa-5">
       <h1>
-        {{ $t('home.getInvolved') }}
+        {{ $t('pages.home.getInvolved') }}
       </h1>
       <v-layout
         wrap
@@ -197,14 +197,14 @@ export default {
     },
     // TODO: The translation doesn't work here
     highlightCards: [
-      { text: this.$t('home.highlightCards.automatedActions'), img: 'actions.webp' },
-      { text: this.$t('home.highlightCards.auditableStats'), img: 'auditable.webp' },
-      { text: this.$t('home.highlightCards.diceRolling'), img: 'automated-dice-rolls.webp' },
-      { text: this.$t('home.highlightCards.hackableChar'), img: 'build-system.webp' },
-      { text: this.$t('home.highlightCards.dragAndDrop'), img: 'inventory.webp' },
-      { text: this.$t('home.highlightCards.customLibraries'), img: 'libraries-of-content.webp' },
-      { text: this.$t('home.highlightCards.discordWebhooks'), img: 'send-to-discord.webp' },
-      { text: this.$t('home.highlightCards.printedCharacters'), img: 'printing.webp' },
+      { text: this.$t('pages.home.highlightCards.automatedActions'), img: 'actions.webp' },
+      { text: this.$t('pages.home.highlightCards.auditableStats'), img: 'auditable.webp' },
+      { text: this.$t('pages.home.highlightCards.diceRolling'), img: 'automated-dice-rolls.webp' },
+      { text: this.$t('pages.home.highlightCards.hackableChar'), img: 'build-system.webp' },
+      { text: this.$t('pages.home.highlightCards.dragAndDrop'), img: 'inventory.webp' },
+      { text: this.$t('pages.home.highlightCards.customLibraries'), img: 'libraries-of-content.webp' },
+      { text: this.$t('pages.home.highlightCards.discordWebhooks'), img: 'send-to-discord.webp' },
+      { text: this.$t('pages.home.highlightCards.printedCharacters'), img: 'printing.webp' },
     ],
   }},
   meteor: {

--- a/app/imports/client/ui/pages/InviteError.vue
+++ b/app/imports/client/ui/pages/InviteError.vue
@@ -6,7 +6,7 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        {{ $t('inviteError.title') }}
+        {{ $t('pages.inviteError.title') }}
       </h2>
       <h3>
         {{ error.reason || error.message || error }}

--- a/app/imports/client/ui/pages/InviteError.vue
+++ b/app/imports/client/ui/pages/InviteError.vue
@@ -6,7 +6,7 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        Invite Error
+        {{ $t('inviteError.title') }}
       </h2>
       <h3>
         {{ error.reason || error.message || error }}

--- a/app/imports/client/ui/pages/InviteSuccess.vue
+++ b/app/imports/client/ui/pages/InviteSuccess.vue
@@ -6,10 +6,10 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        Invite Success
+        {{ $t('inviteSuccess.title') }}
       </h2>
       <h3>
-        You can now use DiceCloud
+        {{ $t('inviteSuccess.description') }}
       </h3>
     </v-layout>
   </div>

--- a/app/imports/client/ui/pages/InviteSuccess.vue
+++ b/app/imports/client/ui/pages/InviteSuccess.vue
@@ -6,10 +6,10 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        {{ $t('inviteSuccess.title') }}
+        {{ $t('pages.inviteSuccess.title') }}
       </h2>
       <h3>
-        {{ $t('inviteSuccess.description') }}
+        {{ $t('pages.inviteSuccess.description') }}
       </h3>
     </v-layout>
   </div>

--- a/app/imports/client/ui/pages/LaunchCountdown.vue
+++ b/app/imports/client/ui/pages/LaunchCountdown.vue
@@ -6,7 +6,7 @@
     class="fill-height"
   >
     <h1>
-      DiceCloud version 2 beta will launch in
+      {{ $t('launchCountdown.title') }}
     </h1>
     <h1 style="font-size: 64px;">
       <countdown
@@ -16,7 +16,7 @@
       >
         <template slot-scope="props">
           <span v-if="props.days">
-            {{ props.days }} days,
+            {{ props.days }} {{ $t('launchCountdown.days') }}
           </span>{{ props.hours }}:{{ formatNumber(props.minutes) }}:{{ formatNumber(props.seconds) }}
         </template>
       </countdown>

--- a/app/imports/client/ui/pages/LaunchCountdown.vue
+++ b/app/imports/client/ui/pages/LaunchCountdown.vue
@@ -6,7 +6,7 @@
     class="fill-height"
   >
     <h1>
-      {{ $t('launchCountdown.title') }}
+      {{ $t('pages.launchCountdown.title') }}
     </h1>
     <h1 style="font-size: 64px;">
       <countdown
@@ -16,7 +16,7 @@
       >
         <template slot-scope="props">
           <span v-if="props.days">
-            {{ props.days }} {{ $t('launchCountdown.days') }}
+            {{ props.days }} {{ $t('pages.launchCountdown.description') }}
           </span>{{ props.hours }}:{{ formatNumber(props.minutes) }}:{{ formatNumber(props.seconds) }}
         </template>
       </countdown>

--- a/app/imports/client/ui/pages/Library.vue
+++ b/app/imports/client/ui/pages/Library.vue
@@ -34,7 +34,7 @@
               text
               to="/community-libraries"
             >
-              {{ $t('library.browse') }}
+              {{ $t('pages.library.browse') }}
             </v-btn>
             <v-btn
               v-if="paidBenefits"
@@ -44,7 +44,7 @@
               :loading="loadingInsertLibraryCollection"
               @click="insertLibraryCollection"
             >
-              {{ $t('library.addCollection') }}
+              {{ $t('pages.library.addCollection') }}
             </v-btn>
           </div>
           <v-btn

--- a/app/imports/client/ui/pages/Library.vue
+++ b/app/imports/client/ui/pages/Library.vue
@@ -34,7 +34,7 @@
               text
               to="/community-libraries"
             >
-              Browse community libraries
+              {{ $t('library.browse') }}
             </v-btn>
             <v-btn
               v-if="paidBenefits"
@@ -44,7 +44,7 @@
               :loading="loadingInsertLibraryCollection"
               @click="insertLibraryCollection"
             >
-              Add Collection
+              {{ $t('library.addCollection') }}
             </v-btn>
           </div>
           <v-btn

--- a/app/imports/client/ui/pages/LibraryBrowser.vue
+++ b/app/imports/client/ui/pages/LibraryBrowser.vue
@@ -47,7 +47,7 @@
                     :color="card.subscribed ? '': 'accent'"
                     @click="ack => changeSubscribe(card, ack)"
                   >
-                    {{ card.subscribed ? 'Unsubscribe' : 'Subscribe' }}
+                    {{ card.subscribed ? $t("pages.libraryBrowser.unsubscribe") : $t("pages.libraryBrowser.subscribe") }}
                   </smart-btn>
                 </v-card-actions>
               </v-card>

--- a/app/imports/client/ui/pages/Maintenance.vue
+++ b/app/imports/client/ui/pages/Maintenance.vue
@@ -9,7 +9,7 @@
       v-if="maintenanceMode"
       class="ma-4 text-h3"
     >
-      {{ $t('maintenance.title') }}
+      {{ $t('pages.maintenance.title') }}
     </h1>
     <template v-else>
       <h1

--- a/app/imports/client/ui/pages/Maintenance.vue
+++ b/app/imports/client/ui/pages/Maintenance.vue
@@ -9,7 +9,7 @@
       v-if="maintenanceMode"
       class="ma-4 text-h3"
     >
-      DiceCloud is currently under maintenance
+      {{ $t('maintenance.title') }}
     </h1>
     <template v-else>
       <h1

--- a/app/imports/client/ui/pages/NotFound.vue
+++ b/app/imports/client/ui/pages/NotFound.vue
@@ -9,7 +9,7 @@
       404
     </h1>
     <h1 class="ma-4 text-h3">
-      No page was found for this address
+      {{ $t('notFound.title') }}
     </h1>
   </v-layout>
 </template>

--- a/app/imports/client/ui/pages/NotFound.vue
+++ b/app/imports/client/ui/pages/NotFound.vue
@@ -9,7 +9,7 @@
       404
     </h1>
     <h1 class="ma-4 text-h3">
-      {{ $t('notFound.title') }}
+      {{ $t('pages.notFound.title') }}
     </h1>
   </v-layout>
 </template>

--- a/app/imports/client/ui/pages/NotImplemented.vue
+++ b/app/imports/client/ui/pages/NotImplemented.vue
@@ -4,7 +4,7 @@
       :value="true"
       type="info"
     >
-      {{ $t('notImplemented.title') }}
+      {{ $t('pages.notImplemented.title') }}
     </v-alert>
   </div>
 </template>

--- a/app/imports/client/ui/pages/NotImplemented.vue
+++ b/app/imports/client/ui/pages/NotImplemented.vue
@@ -4,7 +4,7 @@
       :value="true"
       type="info"
     >
-      This page is not available in this version of DiceCloud.
+      {{ $t('notImplemented.title') }}
     </v-alert>
   </div>
 </template>

--- a/app/imports/client/ui/pages/PatreonLevelTooLow.vue
+++ b/app/imports/client/ui/pages/PatreonLevelTooLow.vue
@@ -6,17 +6,16 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        Your current Patreon tier is {{ tier.name }}
+        {{ $t('patreonLevelTooLow.currentTier') }} {{ tier.name }}
       </h2>
       <h3>
-        You need to be at least Adventurer tier (or be invited by a Patron of
-        a higher tier) to access this beta
+        {{ $t('patreonLevelTooLow.description') }}
       </h3>
       <v-btn
         href="https://www.patreon.com/join/dicecloud/checkout?rid=3002853"
         color="accent"
       >
-        Join now
+        {{ $t('patreonLevelTooLow.joinNow') }}
       </v-btn>
     </v-layout>
   </div>

--- a/app/imports/client/ui/pages/PatreonLevelTooLow.vue
+++ b/app/imports/client/ui/pages/PatreonLevelTooLow.vue
@@ -6,16 +6,16 @@
       justify-center
     >
       <h2 style="margin: 48px 28px 16px">
-        {{ $t('patreonLevelTooLow.currentTier') }} {{ tier.name }}
+        {{ $t('pages.patreonLevelTooLow.currentTier') }} {{ tier.name }}
       </h2>
       <h3>
-        {{ $t('patreonLevelTooLow.description') }}
+        {{ $t('pages.patreonLevelTooLow.description') }}
       </h3>
       <v-btn
         href="https://www.patreon.com/join/dicecloud/checkout?rid=3002853"
         color="accent"
       >
-        {{ $t('patreonLevelTooLow.joinNow') }}
+        {{ $t('pages.patreonLevelTooLow.joinNow') }}
       </v-btn>
     </v-layout>
   </div>

--- a/app/imports/client/ui/pages/Register.vue
+++ b/app/imports/client/ui/pages/Register.vue
@@ -16,7 +16,7 @@
         <v-text-field
           v-model="email"
           type="text"
-          label="Email"
+          :label="$t('pages.register.email')"
           :rules="emailRules"
           class="ma-2"
           outlined
@@ -26,7 +26,7 @@
         <v-text-field
           v-model="username"
           type="text"
-          label="Username"
+          :label="$t('pages.register.username')"
           :rules="usernameRules"
           class="ma-2"
           outlined
@@ -36,7 +36,7 @@
         <v-text-field
           v-model="password"
           type="password"
-          label="Password"
+          :label="$t('pages.register.password')"
           :rules="passwordRules"
           class="ma-2"
           outlined
@@ -46,7 +46,7 @@
         <v-text-field
           v-model="password2"
           type="password"
-          label="Password Again"
+          :label="$t('pages.register.password2')"
           :rules="password2Rules"
           class="ma-2"
           outlined
@@ -62,7 +62,7 @@
             color="accent"
             @click="submit"
           >
-            Register
+            {{ $t('pages.register.register') }}
           </v-btn>
         </v-layout>
       </v-layout>
@@ -79,7 +79,7 @@
         color="accent"
         @click="googleLogin"
       >
-        Register in with Google
+        {{ $t('pages.register.googleLogin') }}
       </v-btn>
     </v-layout>
   </div>
@@ -91,26 +91,36 @@
       return {
         valid: true,
         username: '',
-        usernameRules: [
-          v => !!v || 'Name is required',
-        ],
         email: '',
-        emailRules: [
-          v => !!v || 'E-mail is required',
-          v => /.+@.+/.test(v) || 'E-mail must be valid',
-        ],
         password: '',
-        passwordRules: [
-          v => !!v || 'Password is required',
-        ],
         password2: '',
-        password2Rules: [
-          v => !!v || 'Password is required',
-          v => v == this.password || 'Passwords don\'t match',
-        ],
         error: '',
         googleError: '',
       }
+    },
+    computed: {
+      usernameRules() {
+        return [
+          v => !!v || this.$t('pages.register.errors.nameIsRequired'),
+        ];
+      },
+      emailRules() {
+        return [
+          v => !!v || this.$t('pages.register.errors.emailIsRequired'),
+          v => /.+@.+/.test(v) || this.$t('pages.register.errors.emailIsInvalid'),
+        ];
+      },
+      passwordRules() {
+        return [
+          v => !!v || this.$t('pages.register.errors.passwordIsRequired'),
+        ];
+      },
+      password2Rules() {
+        return [
+          v => !!v || this.$t('pages.register.errors.passwordIsRequired'),
+          v => v === this.password || this.$t('pages.register.errors.passwordsDontMatch'),
+        ];
+      },
     },
     methods: {
       submit () {

--- a/app/imports/client/ui/pages/ResetPassword.vue
+++ b/app/imports/client/ui/pages/ResetPassword.vue
@@ -18,7 +18,7 @@
           <v-text-field
             v-model="password"
             type="password"
-            label="New Password"
+            :label="$t('pages.resetPassword.password')"
             :rules="passwordRules"
             class="ma-2"
             outlined
@@ -28,7 +28,7 @@
           <v-text-field
             v-model="password2"
             type="password"
-            label="Password Again"
+            :label="$t('pages.resetPassword.password2')"
             :rules="password2Rules"
             class="ma-2"
             outlined
@@ -40,7 +40,7 @@
           v-else
           v-model="email"
           type="text"
-          label="Email"
+          :label="$t('pages.resetPassword.email')"
           :rules="emailRules"
           class="ma-2"
           outlined
@@ -69,7 +69,7 @@
             color="accent"
             @click="submit"
           >
-            Reset Password
+            {{ $t('pages.resetPassword.resetPassword') }}
           </v-btn>
         </v-layout>
       </v-layout>
@@ -85,17 +85,17 @@
         submitLoading: false,
         email: '',
         emailRules: [
-          v => !!v || 'E-mail is required',
-          v => /.+@.+/.test(v) || 'E-mail must be valid',
+          v => !!v || this.$t('pages.resetPassword.errors.emailIsRequired'),
+          v => /.+@.+/.test(v) || this.$t('pages.resetPassword.errors.emailIsInvalid'),
         ],
         password: '',
         passwordRules: [
-          v => !!v || 'Password is required',
+          v => !!v || this.$t('pages.resetPassword.errors.passwordIsRequired'),
         ],
         password2: '',
         password2Rules: [
-          v => !!v || 'Password is required',
-          v => v == this.password || 'Passwords don\'t match',
+          v => !!v || this.$t('pages.resetPassword.errors.passwordIsRequired'),
+          v => v == this.password || this.$t('pages.resetPassword.errors.passwordsDontMatch'),
         ],
         error: '',
         info: '',
@@ -126,7 +126,7 @@
               this.error = error && error.message;
               this.info = '';
               if (!error){
-                this.info = `Password reset link sent to ${this.email}`;
+                this.info = this.$t('pages.resetPassword.passwordResetLink', {email: this.email});
                 this.email = '';
                 this.valid = true;
               }

--- a/app/imports/client/ui/pages/SignIn.vue
+++ b/app/imports/client/ui/pages/SignIn.vue
@@ -16,7 +16,7 @@
         <v-text-field
           v-model="name"
           type="text"
-          label="Username or email"
+          :label="$t('pages.signIn.usernameOrEmail')"
           :rules="nameRules"
           class="ma-2"
           outlined
@@ -26,7 +26,7 @@
         <v-text-field
           v-model="password"
           type="password"
-          label="Password"
+          :label="$t('pages.signIn.password')"
           :rules="passwordRules"
           class="ma-2"
           outlined
@@ -37,7 +37,7 @@
           text
           to="/reset-password"
         >
-          Reset Password
+          {{ $t('pages.signIn.resetPassword') }}
         </v-btn>
         <div
           v-if="error"
@@ -52,21 +52,21 @@
             class="ma-2"
             @click="submit"
           >
-            Sign In
+            {{ $t('pages.signIn.signIn') }}
           </v-btn>
           <v-btn
             color="accent"
             :to="{ name: 'register', query: { redirect: $route.query.redirect} }"
             class="ma-2"
           >
-            Register
+            {{ $t('pages.signIn.register') }}
           </v-btn>
         </v-layout>
         <div class="text-caption mt-4 px-4">
           <p>
-            DiceCloud Version 2 requires a new account to use.
+            {{ $t('pages.signIn.diceV2') }}
           </p><p>
-            Version 1 is still available at <a href="https://v1.dicecloud.com">v1.dicecloud.com</a>
+            {{ $t('pages.signIn.diceV1') }} <a href="https://v1.dicecloud.com">v1.dicecloud.com</a>
           </p>
         </div>
       </v-layout>
@@ -84,7 +84,7 @@
         class="ma-2"
         @click="googleLogin"
       >
-        Sign in with Google
+        {{ $t('pages.signIn.googleLogin') }}
       </v-btn>
       <div class="error--text">
         {{ patreonError }}
@@ -94,7 +94,7 @@
         class="ma-2"
         @click="patreonLogin"
       >
-        Sign in with Patreon
+        {{ $t('pages.signIn.signInPatreon') }}
       </v-btn>
     </v-layout>
   </div>
@@ -106,11 +106,11 @@ export default {
     valid: true,
     name: '',
     nameRules: [
-      v => !!v || 'Name is required',
+      v => !!v || this.$t('pages.signIn.errors.nameIsRequired'),
     ],
     password: '',
     passwordRules: [
-      v => !!v || 'Password is required',
+      v => !!v || this.$t('pages.signIn.errors.passwordIsRequired'),
     ],
     error: '',
     googleError: '',

--- a/app/imports/client/ui/pages/SingleLibrary.vue
+++ b/app/imports/client/ui/pages/SingleLibrary.vue
@@ -18,11 +18,11 @@ export default {
   },
   watch: {
     'library.name'(newName) {
-      this.$store.commit('setPageTitle', newName || 'Library');
+      this.$store.commit('setPageTitle', newName || this.$t('pages.singleLibrary.title'));
     },
   },
   mounted() {
-    this.$store.commit('setPageTitle', this.library && this.library.name || 'Library');
+    this.$store.commit('setPageTitle', this.library && this.library.name || this.$t('pages.singleLibrary.title'));
   },
   meteor: {
     library(){

--- a/app/imports/client/ui/pages/Tabletop.vue
+++ b/app/imports/client/ui/pages/Tabletop.vue
@@ -40,8 +40,8 @@
           cols="12"
           md="8"
         >
-          <p>This tabletop was not found</p>
-          <p>Either it does not exist, or you do not have permission to view it</p>
+          <p>{{ $t("pages.tabletop.notFound") }}</p>
+          <p>{{ $t("pages.tabletop.notFoundDescription") }}</p>
         </v-col>
       </v-row>
     </v-container>

--- a/app/imports/client/ui/pages/Tabletops.vue
+++ b/app/imports/client/ui/pages/Tabletops.vue
@@ -78,7 +78,7 @@
             cols="12"
             class="d-flex align-center justify-center"
           >
-            <h1>You don't have any tabletops yet</h1>
+            <h1>{{ $t("pages.tabletops.dontHaveAny") }}</h1>
           </v-col>
         </v-row>
       </v-fade-transition>

--- a/app/imports/client/ui/properties/InsertPropertyDialog.vue
+++ b/app/imports/client/ui/properties/InsertPropertyDialog.vue
@@ -3,7 +3,7 @@
     <template slot="toolbar">
       <v-toolbar-title class="mr-4">
         <template v-if="tab === 2">
-          New
+          {{ $t('properties.insertPropertyDialog.new') }}
         </template>{{ typeName }}
       </v-toolbar-title>
       <v-spacer />
@@ -40,16 +40,16 @@
       v-model="tab"
     >
       <v-tab :disabled="!!forcedType">
-        {{ typeName || 'Type' }}
+        {{ typeName || $t('properties.insertPropertyDialog.type') }}
       </v-tab>
       <v-tab :disabled="!type">
-        Create
+        {{ $t('properties.insertPropertyDialog.create') }}
       </v-tab>
       <v-tab
         v-if="!hideLibraryTab"
         :disabled="!type"
       >
-        Library
+        {{ $t('properties.insertPropertyDialog.library') }}
       </v-tab>
     </v-tabs>
     <v-tabs-items
@@ -153,7 +153,7 @@
                 class="ma-4"
                 @click="loadMore"
               >
-                Load More
+                {{ $t('properties.insertPropertyDialog.loadMore') }}
               </v-btn>
             </div>
           </v-fade-transition>
@@ -165,7 +165,7 @@
         text
         @click="$store.dispatch('popDialogStack')"
       >
-        {{ tab === 1 ? "Discard" : "Cancel" }}
+        {{ tab === 1 ? $t('properties.insertPropertyDialog.discard') : $t('properties.insertPropertyDialog.cancel') }}
       </v-btn>
       <v-spacer />
       <v-btn
@@ -175,7 +175,7 @@
         :disabled="!valid"
         @click="$store.dispatch('popDialogStack', model)"
       >
-        create
+        {{ $t('properties.insertPropertyDialog.create') }}
       </v-btn>
       <v-btn
         v-else-if="tab === 2"
@@ -187,7 +187,7 @@
         <template v-if="selectedNodeIds.length >= 15">
           {{ selectedNodeIds.length }}/20
         </template>
-        Insert
+        {{ $t('properties.insertPropertyDialog.insert') }}
       </v-btn>
     </template>
   </dialog-base>

--- a/app/imports/client/ui/properties/PropertyForm.vue
+++ b/app/imports/client/ui/properties/PropertyForm.vue
@@ -9,7 +9,7 @@
         <text-field
           v-if="schemaHasName"
           ref="focusFirst"
-          label="Name"
+          :label="$t('properties.propertyForm.name')"
           style="flex-basis: 320px;"
           :value="model.name"
           :error-messages="errors.name"
@@ -32,7 +32,7 @@
     >
       <form-section
         v-if="context.isLibraryForm"
-        name="Library"
+        :name="$t('properties.propertyForm.library')"
       >
         <v-row
           v-if="context.isLibraryForm"
@@ -43,7 +43,7 @@
             md="6"
           >
             <smart-switch
-              label="Can fill slots"
+              :label="$t('properties.propertyForm.canFillSlots')"
               :value="model.fillSlots"
               :error-messages="errors.fillSlots"
               @change="(value, ack) => $emit('change', {path: ['fillSlots'], value, ack})"
@@ -54,7 +54,7 @@
             md="6"
           >
             <smart-switch
-              label="Searchable from character sheet"
+              :label="$t('properties.propertyForm.searchable')"
               :value="model.searchable"
               :error-messages="errors.searchable"
               @change="(value, ack) => $emit('change', {path: ['searchable'], value, ack})"
@@ -65,10 +65,10 @@
             md="6"
           >
             <smart-select
-              label="Slot fill type"
+              :label="$t('properties.propertyForm.slotFillType')"
               style="flex-basis: 300px;"
               clearable
-              hint="The property type that this slot filler pretends to be when being searched for by a slot"
+              :hint="$t('properties.propertyForm.slotFillTypeHint')"
               :items="slotTypes"
               :value="model.slotFillerType"
               :error-messages="errors.slotFillerType"
@@ -80,10 +80,10 @@
             md="6"
           >
             <text-field
-              label="Slot quantity filled"
+              :label="$t('properties.propertyForm.slotQuantityFilled')"
               type="number"
               min="0"
-              hint="How many properties this counts as when filling a slot"
+              :hint="$t('properties.propertyForm.slotQuantityFilledHint')"
               :value="model.slotQuantityFilled"
               :error-messages="errors.slotQuantityFilled"
               @change="(value, ack) => $emit('change', {path: ['slotQuantityFilled'], value, ack})"
@@ -95,8 +95,8 @@
           >
             <text-field
               v-if="context.isLibraryForm"
-              label="Condition"
-              hint="A caclulation to determine if this property can be added to a character"
+              :label="$t('properties.propertyForm.condition')"
+              :hint="$t('properties.propertyForm.conditionHint')"
               placeholder="Always active"
               :value="model.slotFillerCondition"
               :error-messages="errors.slotFillerCondition"
@@ -109,8 +109,8 @@
           >
             <text-field
               v-if="context.isLibraryForm"
-              label="Condition Error Text"
-              hint="Text to display if the condition isn't met"
+              :label="$t('properties.propertyForm.conditionErrorText')"
+              :hint="$t('properties.propertyForm.conditionErrorTextHint')"
               placeholder="Always active"
               :value="model.slotFillerConditionNote"
               :error-messages="errors.slotFillerConditionNote"
@@ -121,11 +121,11 @@
             cols="12"
           >
             <smart-combobox
-              label="Library Tags"
+              :label="$t('properties.propertyForm.libraryTags')"
               multiple
               small-chips
               deletable-chips
-              hint="Used to let slots find this property in a library"
+              :hint="$t('properties.propertyForm.libraryTagsHint')"
               :value="model.libraryTags"
               :error-messages="errors.libraryTags"
               @change="(value, ack) => $emit('change', {path: ['libraryTags'], value, ack})"
@@ -142,11 +142,11 @@
         cols="12"
       >
         <smart-combobox
-          label="Tags"
+          :label="$t('properties.propertyForm.tags')"
           multiple
           small-chips
           deletable-chips
-          hint="Tags let other properties target this property with interactions"
+          :hint="$t('properties.propertyForm.tagsHint')"
           :value="model.tags"
           :error-messages="errors.tags"
           @change="(value, ack) => $emit('change', {path: ['tags'], value, ack})"
@@ -163,7 +163,7 @@
         style="gap: 8px"
       >
         <outlined-input
-          name="Child properties"
+          :name="$t('properties.propertyForm.childProperties')"
           style="width: 100%"
           class="pa-2 no-hover"
         >
@@ -202,13 +202,13 @@
             >
               mdi-plus
             </v-icon>
-            {{ suggestedChildren.length ? '...Other' : 'Child' }}
+            {{ suggestedChildren.length ? $t('properties.propertyForm.other') : $t('properties.propertyForm.child') }}
           </v-btn>
           <div
             v-if="noChildInsert"
             class="ma-2 text--disabled"
           >
-            Children can be added after this property is created
+            {{ $t('properties.propertyForm.childrenCanBeAdded') }}
           </div>
         </outlined-input>
       </v-col>

--- a/app/imports/client/ui/properties/forms/ActionForm.vue
+++ b/app/imports/client/ui/properties/forms/ActionForm.vue
@@ -9,14 +9,14 @@
           <v-switch
             v-if="!isAttack"
             class="ml-4"
-            label="Attack roll"
+            :label="$t('properties.forms.actionForm.attackRoll')"
             :value="attackSwitch"
             @change="e => attackSwitch = e"
           />
           <computed-field
             v-else
-            label="Base attack roll bonus"
-            hint="Must be set for the action to have an attack roll"
+            :label="$t('properties.forms.actionForm.baseAttackRollBonus')"
+            :hint="$t('properties.forms.actionForm.baseAttackRollHint')"
             :model="model.attackRoll"
             :error-messages="errors.attackRoll"
             @change="({path, value, ack}) =>
@@ -40,7 +40,7 @@
         md="4"
       >
         <smart-select
-          label="Action type"
+          :label="$t('properties.forms.actionForm.actionType')"
           :items="actionTypes"
           :value="model.actionType"
           :error-messages="errors.actionType"
@@ -54,29 +54,29 @@
     <v-slide-x-transition mode="out-in">
       <text-field
         v-if="model.actionType === 'event'"
-        label="Event variable name"
+        :label="$t('properties.forms.actionForm.eventVariableName')"
         :value="model.variableName"
-        hint="Variable name of the event that this action represents"
+        :hint="$t('properties.forms.actionForm.eventVariableNameHint')"
         :error-messages="errors.variableName"
         @change="change('variableName', ...arguments)"
       />
     </v-slide-x-transition>
 
     <smart-toggle
-      label="Target creature"
+      :label="$t('properties.forms.actionForm.targetCreature')"
       :value="model.target"
       :options="[
-        {name: 'Single Target', value: 'singleTarget'},
-        {name: 'Multiple Targets', value: 'multipleTargets'},
-        {name: 'Self', value: 'self'},
+        {name: $t('properties.forms.actionForm.singleTarget'), value: 'singleTarget'},
+        {name: $t('properties.forms.actionForm.multipleTargets'), value: 'multipleTargets'},
+        {name: $t('properties.forms.actionForm.self'), value: 'self'},
       ]"
       :error-messages="errors.target"
       @change="change('target', ...arguments)"
     />
 
     <inline-computation-field
-      label="Summary"
-      hint="This will appear in the action card in the character sheet, summarise what the action does. This text will be displayed in the log when the action is taken"
+      :label="$t('properties.forms.common.summary')"
+      :hint="$t('properties.forms.actionForm.summaryHint')"
       :model="model.summary"
       :error-messages="errors['summary.text']"
       @change="({path, value, ack}) =>
@@ -84,7 +84,7 @@
     />
 
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -92,7 +92,7 @@
     />
 
     <form-sections type="action">
-      <form-section name="Resources Consumed">
+      <form-section :name="$t('properties.forms.common.resourcesConsumed')">
         <resources-form
           :model="model.resources"
           @change="({path, value, ack}) => $emit('change', {path: ['resources', ...path], value, ack})"
@@ -100,15 +100,15 @@
           @pull="({path, ack}) => $emit('pull', {path: ['resources', ...path], ack})"
         />
       </form-section>
-      <form-section name="Limit Uses">
+      <form-section :name="$t('properties.forms.common.limitUses')">
         <v-row dense>
           <v-col
             cols="12"
             md="6"
           >
-            <computed-field
-              label="Uses"
-              hint="How many times this action can be used before needing to be reset"
+          <computed-field
+              :label="$t('properties.forms.common.uses')"
+              :hint="$t('properties.forms.common.usesHint')"
               class="mr-2"
               :model="model.uses"
               :error-messages="errors.uses"
@@ -121,9 +121,9 @@
             md="6"
           >
             <text-field
-              label="Uses used"
+              :label="$t('properties.forms.common.usesUsed')"
               type="number"
-              hint="How many times this action has already been used: should be 0 in most cases"
+              :hint="$t('properties.forms.common.usesUsedHint')"
               style="flex-basis: 300px;"
               :value="model.usesUsed"
               :error-messages="errors.uses"
@@ -138,9 +138,9 @@
           @change="change('reset', ...arguments)"
         />
       </form-section>
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           class="ml-4 mt-0 mb-4"
           :value="model.silent"
           :error-messages="errors.silent"

--- a/app/imports/client/ui/properties/forms/AdjustmentForm.vue
+++ b/app/imports/client/ui/properties/forms/AdjustmentForm.vue
@@ -6,8 +6,8 @@
         md="6"
       >
         <smart-combobox
-          label="Attribute"
-          hint="The attribute that will be damaged or healed"
+          :label="$t('properties.forms.adjustmentForm.attribute')"
+          :hint="$t('properties.forms.adjustmentForm.attributeHint')"
           style="flex-basis: 300px;"
           :items="attributeList"
           :value="model.stat"
@@ -20,7 +20,7 @@
         md="6"
       >
         <computed-field
-          label="Amount"
+          :label="$t('properties.forms.adjustmentForm.amount')"
           :hint="model.operation === 'set' ? setHint : damageHint"
           :model="model.amount"
           :error-messages="errors.amount"
@@ -35,12 +35,12 @@
         md="6"
       >
         <smart-toggle
-          label="Operation"
-          hint="Should the attribute be damaged by the amount, or set to the amount"
+          :label="$t('properties.forms.adjustmentForm.operation')"
+          :hint="$t('properties.forms.adjustmentForm.operationHint')"
           :value="model.operation"
           :options="[
-            { name: 'Damage', value: 'increment' },
-            { name: 'Set', value: 'set' },
+            { name: $t('properties.forms.adjustmentForm.damageOption'), value: 'increment' },
+            { name: $t('properties.forms.adjustmentForm.setOption'), value: 'set' },
           ]"
           :error-messages="errors.operation"
           @change="change('operation', ...arguments)"
@@ -51,11 +51,11 @@
         md="6"
       >
         <smart-toggle
-          label="Target creature"
+          :label="$t('properties.forms.savingThrowForm.targetCreature')"
           :value="model.target"
           :options="[
-            {name: 'Action Target', value: 'target'},
-            {name: 'Self', value: 'self'},
+            {name: $t('properties.forms.savingThrowForm.actionTarget'), value: 'target'},
+            {name: $t('properties.forms.savingThrowForm.self'), value: 'self'},
           ]"
           :error-messages="errors.target"
           @change="change('target', ...arguments)"
@@ -63,9 +63,9 @@
       </v-col>
     </v-row>
     <form-sections type="adjustment">
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"
@@ -84,8 +84,8 @@ export default {
   mixins: [propertyFormMixin, attributeListMixin],
   data() {
     return {
-      damageHint: 'The amount of damage to apply, negative values will heal',
-      setHint: 'The value to set the stat to',
+      damageHint: this.$t('properties.forms.adjustmentForm.damageHint'),
+      setHint: this.$t('properties.forms.adjustmentForm.setHint'),
     }
   },
 }

--- a/app/imports/client/ui/properties/forms/AttributeForm.vue
+++ b/app/imports/client/ui/properties/forms/AttributeForm.vue
@@ -6,9 +6,9 @@
         md="6"
       >
         <text-field
-          label="Variable name"
+          :label="$t('properties.forms.common.variableName')"
           :value="model.variableName"
-          hint="Use this name in calculations to reference this attribute"
+          :hint="$t('properties.forms.common.variableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
@@ -19,9 +19,9 @@
       >
         <computed-field
           ref="focusFirst"
-          label="Base Value"
+          :label="$t('properties.forms.common.baseValue')"
           class="base-value-field"
-          hint="This is the value of the attribute before effects are applied. Can be a number or a calculation"
+          :hint="$t('properties.forms.common.baseValueHint')"
           :model="model.baseValue"
           :error-messages="errors.baseValue"
           @change="({path, value, ack}) =>
@@ -30,7 +30,7 @@
       </v-col>
       <v-col cols="12">
         <smart-select
-          label="Type"
+          :label="$t('properties.forms.common.type')"
           :items="attributeTypes"
           :value="model.attributeType"
           :error-messages="errors.attributeType"
@@ -58,7 +58,7 @@
           cols="12"
         >
           <computed-field
-            label="Spell slot level"
+            :label="$t('properties.forms.attributeForm.spellSlotLevel')"
             :model="model.spellSlotLevel"
             :error-messages="errors.spellSlotLevel"
             @change="({path, value, ack}) =>
@@ -68,7 +68,7 @@
       </v-expand-transition>
     </v-row>
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -78,17 +78,17 @@
       <v-expand-transition>
         <form-section
           v-if="model.attributeType === 'healthBar'"
-          name="Health Bar"
+          :name="$t('properties.forms.attributeForm.healthBar')"
         >
           <div class="d-flex flex-column align-center mb-4">
             <div class="text-caption mb-4">
-              Damaged Colors
+              {{ $t('properties.forms.attributeForm.damagedColors') }}
             </div>
             <div
               class="d-flex flex-wrap align-center justify-start"
             >
               <outlined-input
-                name="Half"
+                :name="$t('properties.forms.attributeForm.half')"
                 class="mb-4"
               >
                 <color-picker
@@ -99,7 +99,7 @@
                 />
               </outlined-input>
               <outlined-input
-                name="Empty"
+                :name="$t('properties.forms.attributeForm.empty')"
                 class="mb-4 ml-2"
               >
                 <color-picker
@@ -117,9 +117,9 @@
               md="4"
             >
               <text-field
-                label="Damage order"
+                :label="$t('properties.forms.attributeForm.damageOrder')"
                 type="number"
-                hint="Lower ordered health bars will take damage before higher ordered ones"
+                :hint="$t('properties.forms.attributeForm.damageOrderHint')"
                 :disabled="model.healthBarNoDamage"
                 :value="model.healthBarDamageOrder"
                 :error-messages="errors.healthBarDamageOrder"
@@ -132,7 +132,7 @@
               sm="6"
             >
               <smart-switch
-                label="Ignore damage"
+                :label="$t('properties.forms.attributeForm.ignoreDamage')"
                 :value="model.healthBarNoDamage"
                 :error-messages="errors.healthBarNoDamage"
                 @change="change('healthBarNoDamage', ...arguments)"
@@ -144,7 +144,7 @@
               sm="6"
             >
               <smart-switch
-                label="Prevent damage overflow"
+                :label="$t('properties.forms.attributeForm.preventDamageOverflow')"
                 :value="model.healthBarNoDamageOverflow"
                 :error-messages="errors.healthBarNoDamageOverflow"
                 @change="change('healthBarNoDamageOverflow', ...arguments)"
@@ -155,9 +155,9 @@
               md="4"
             >
               <text-field
-                label="Healing order"
+                :label="$t('properties.forms.attributeForm.healingOrder')"
                 type="number"
-                hint="Lower ordered health bars will take healing before higher ordered ones"
+                :hint="$t('properties.forms.attributeForm.healingOrderHint')"
                 :disabled="model.healthBarNoHealing"
                 :value="model.healthBarHealingOrder"
                 :error-messages="errors.healthBarHealingOrder"
@@ -170,7 +170,7 @@
               sm="6"
             >
               <smart-switch
-                label="Ignore healing"
+                :label="$t('properties.forms.attributeForm.ignoreHealing')"
                 :value="model.healthBarNoHealing"
                 :error-messages="errors.healthBarNoHealing"
                 @change="change('healthBarNoHealing', ...arguments)"
@@ -182,7 +182,7 @@
               sm="6"
             >
               <smart-switch
-                label="Prevent healing overflow"
+                :label="$t('properties.forms.attributeForm.preventHealingOverflow')"
                 :value="model.healthBarNoHealingOverflow"
                 :error-messages="errors.healthBarNoHealingOverflow"
                 @change="change('healthBarNoHealingOverflow', ...arguments)"
@@ -198,10 +198,10 @@
             md="6"
           >
             <text-field
-              label="Damage"
+              :label="$t('properties.forms.common.damage')"
               type="number"
               class="damage-field text-center"
-              hint="Damage reduces the attribute's final value"
+              :hint="$t('properties.forms.common.damageHint')"
               :disabled="!context.isLibraryForm"
               :value="model.damage"
               :error-messages="errors.damage"
@@ -214,7 +214,7 @@
           >
             <reset-selector
               v-if="model.attributeType !== 'hitDice'"
-              hint="When damage should be reset to zero"
+              :hint="$t('properties.forms.attributeForm.resetHint')"
               :value="model.reset"
               :error-messages="errors.reset"
               @change="change('reset', ...arguments)"
@@ -231,7 +231,7 @@
           >
             <smart-switch
               v-if="model.attributeType !== 'hitDice'"
-              label="Allow decimal values"
+              :label="$t('properties.forms.attributeForm.allowDecimalValues')"
               class="mx-4"
               :value="model.decimal"
               :error-messages="errors.decimal"
@@ -244,7 +244,7 @@
             md="4"
           >
             <smart-switch
-              label="Can be damaged into negative values"
+              :label="$t('properties.forms.attributeForm.canBeDamagedNegative')"
               class="mx-4"
               :value="model.ignoreLowerLimit"
               :error-messages="errors.ignoreLowerLimit"
@@ -257,7 +257,7 @@
             md="4"
           >
             <smart-switch
-              label="Can be incremented above total"
+              :label="$t('properties.forms.attributeForm.canBeIncrementedAboveTotal')"
               class="mx-4"
               :value="model.ignoreUpperLimit"
               :error-messages="errors.ignoreUpperLimit"
@@ -270,7 +270,7 @@
             md="4"
           >
             <smart-switch
-              label="Hide when total is zero"
+              :label="$t('properties.forms.attributeForm.hideWhenTotalZero')"
               class="mx-4"
               :value="model.hideWhenTotalZero"
               :error-messages="errors.hideWhenTotalZero"
@@ -283,7 +283,7 @@
             md="4"
           >
             <smart-switch
-              label="Hide when value is zero"
+              :label="$t('properties.forms.attributeForm.hideWhenValueZero')"
               class="mx-4"
               :value="model.hideWhenValueZero"
               :error-messages="errors.hideWhenValueZero"

--- a/app/imports/client/ui/properties/forms/BranchForm.vue
+++ b/app/imports/client/ui/properties/forms/BranchForm.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div class="buff-form">
     <smart-select
-      label="Branch Type"
+      :label="$t('properties.forms.branchForm.branchType')"
       :items="typeOptions"
       :hint="typeHint"
       :value="model.branchType"
@@ -12,8 +12,8 @@
     <v-expand-transition>
       <computed-field
         v-if="model.branchType === 'if'"
-        label="Condition"
-        hint="If this resolved to a true value, the child properties will be applied"
+        :label="$t('properties.forms.branchForm.condition')"
+        :hint="$t('properties.forms.branchForm.conditionHint')"
         :model="model.condition"
         :error-messages="errors.condition"
         @change="({path, value, ack}) =>
@@ -21,8 +21,8 @@
       />
       <computed-field
         v-else-if="model.branchType === 'index'"
-        label="Index"
-        hint="Which child to apply. An index of 2 will choose the 2nd child."
+        :label="$t('properties.forms.branchForm.index')"
+        :hint="$t('properties.forms.branchForm.indexHint')"
         :model="model.condition"
         :error-messages="errors.condition"
         @change="({path, value, ack}) =>
@@ -30,9 +30,9 @@
       />
     </v-expand-transition>
     <form-sections type="branch">
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/properties/forms/BuffForm.vue
+++ b/app/imports/client/ui/properties/forms/BuffForm.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div class="buff-form">
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -20,11 +20,11 @@
     -->
     <smart-toggle
       v-if="!model.applied"
-      label="Target creature"
+      :label="$t('properties.forms.buffForm.targetCreature')"
       :value="model.target"
       :options="[
-        {name: 'Action Target', value: 'target'},
-        {name: 'Self', value: 'self'},
+        {name: $t('properties.forms.buffForm.actionTarget'), value: 'target'},
+        {name: $t('properties.forms.buffForm.self'), value: 'self'},
       ]"
       :error-messages="errors.target"
       @change="change('target', ...arguments)"
@@ -32,12 +32,12 @@
     <form-sections type="buff">
       <form-section
         v-if="$slots.children"
-        name="Children"
+        :name="$t('properties.forms.buffForm.children')"
         standalone
       >
         <slot name="children" />
       </form-section>
-      <form-section name="Behavior">
+      <form-section :name="$t('properties.forms.common.behavior')">
         <v-row dense>
           <v-col
             cols="12"
@@ -45,7 +45,7 @@
             md="4"
           >
             <smart-switch
-              label="Hide remove button"
+              :label="$t('properties.forms.buffForm.hideRemoveButton')"
               :value="model.hideRemoveButton"
               :error-messages="errors.hideRemoveButton"
               @change="change('hideRemoveButton', ...arguments)"
@@ -57,7 +57,7 @@
             md="4"
           >
             <smart-switch
-              label="Don't freeze variables"
+              :label="$t('properties.forms.buffForm.dontFreezeVariables')"
               :value="model.skipCrystalization"
               :error-messages="errors.skipCrystalization"
               @change="change('skipCrystalization', ...arguments)"
@@ -65,9 +65,9 @@
           </v-col>
         </v-row>
       </form-section>
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/properties/forms/BuffRemoverForm.vue
+++ b/app/imports/client/ui/properties/forms/BuffRemoverForm.vue
@@ -1,11 +1,11 @@
 <template lang="html">
   <div class="buff-remover-form">
     <smart-toggle
-      label="Target buffs"
+      :label="$t('properties.forms.buffRemoverForm.targetBuffs')"
       :value="model.targetParentBuff ? 'parent' : 'tag'"
       :options="[
-        {name: 'Remove tagged buffs', value: 'tag'},
-        {name: 'Remove parent buff', value: 'parent'},
+        {name: $t('properties.forms.buffRemoverForm.removeTaggedBuffs'), value: 'tag'},
+        {name: $t('properties.forms.buffRemoverForm.removeParentBuff'), value: 'parent'},
       ]"
       @change="(value, ack) => change('targetParentBuff', value === 'parent' ? true : undefined, ack)"
     />
@@ -25,11 +25,11 @@
             md="6"
           >
             <smart-toggle
-              label="Remove matching buffs"
+              :label="$t('properties.forms.buffRemoverForm.removeMatchingBuffs')"
               :value="model.removeAll ? 'all' : 'one'"
               :options="[
-                {name: 'Remove 1 buff', value: 'one'},
-                {name: 'Remove all buffs', value: 'all'},
+                {name: $t('properties.forms.buffRemoverForm.remove1Buff'), value: 'one'},
+                {name: $t('properties.forms.buffRemoverForm.removeAllBuffs'), value: 'all'},
               ]"
               @change="(value, ack) => change('removeAll', value === 'all' ? true : undefined, ack)"
             />
@@ -39,11 +39,11 @@
             md="6"
           >
             <smart-toggle
-              label="Target creature"
+              :label="$t('properties.forms.savingThrowForm.targetCreature')"
               :value="model.target"
               :options="[
-                {name: 'Action Target', value: 'target'},
-                {name: 'Self', value: 'self'},
+                {name: $t('properties.forms.savingThrowForm.actionTarget'), value: 'target'},
+                {name: $t('properties.forms.savingThrowForm.self'), value: 'self'},
               ]"
               :error-messages="errors.target"
               @change="change('target', ...arguments)"
@@ -55,16 +55,16 @@
     <form-sections type="buffRemover">
       <form-section
         v-if="$slots.children"
-        name="Children"
+        :name="$t('properties.forms.damageMultiplierForm.children')"
         standalone
       >
         <slot name="children" />
       </form-section>
       <form-section
-        name="Log"
+        :name="$t('properties.forms.common.log')"
       >
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/properties/forms/ClassForm.vue
+++ b/app/imports/client/ui/properties/forms/ClassForm.vue
@@ -5,9 +5,9 @@
         cols="12"
       >
         <text-field
-          label="Variable name"
+          :label="$t('properties.forms.common.variableName')"
           :value="model.variableName"
-          hint="Use this name in calculations to reference this class"
+          :hint="$t('properties.forms.classForm.variableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
@@ -15,7 +15,7 @@
     </v-row>
 
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -23,7 +23,7 @@
     />
 
     <form-sections type="class">
-      <form-section name="Class levels from libraries">
+      <form-section :name="$t('properties.forms.classForm.classLevelsFromLibraries')">
         <tag-targeting
           :model="model"
           :errors="errors"
@@ -37,9 +37,9 @@
         />
 
         <computed-field
-          label="Active condition"
-          hint="A calculation to determine if this class can have class levels added to it"
-          placeholder="Always active"
+          :label="$t('properties.forms.classForm.activeCondition')"
+          :hint="$t('properties.forms.classForm.activeConditionHint')"
+          :placeholder="$t('properties.forms.slotForm.alwaysActive')"
           :model="model.slotCondition"
           :error-messages="errors.slotCondition"
           @change="({path, value, ack}) =>

--- a/app/imports/client/ui/properties/forms/ClassLevelForm.vue
+++ b/app/imports/client/ui/properties/forms/ClassLevelForm.vue
@@ -6,10 +6,10 @@
         md="6"
       >
         <text-field
-          label="Class variable name"
+          :label="$t('properties.forms.classLevelForm.classVariableName')"
           :value="model.variableName"
           style="flex-basis: 300px;"
-          hint="This should be the same as the class's variable name"
+          :hint="$t('properties.forms.classLevelForm.classVariableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
@@ -19,7 +19,7 @@
         md="6"
       >
         <text-field
-          label="Level"
+          :label="$t('properties.forms.classLevelForm.level')"
           type="number"
           class="base-value-field text-center large-format no-flex"
           :value="model.level"
@@ -30,8 +30,8 @@
     </v-row>
 
     <inline-computation-field
-      label="Description"
-      hint="A brief description of what this class level gives a character"
+      :label="$t('properties.forms.common.description')"
+      :hint="$t('properties.forms.classLevelForm.descriptionHint')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>

--- a/app/imports/client/ui/properties/forms/ConstantForm.vue
+++ b/app/imports/client/ui/properties/forms/ConstantForm.vue
@@ -3,18 +3,18 @@
     <v-row dense>
       <v-col cols="12">
         <text-field
-          label="Variable name"
+          :label="$t('properties.forms.common.variableName')"
           :value="model.variableName"
           style="flex-basis: 300px;"
-          hint="Use this name in calculations to reference this attribute"
+          :hint="$t('properties.forms.constantForm.variableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
       </v-col>
       <v-col cols="12">
         <text-field
-          label="Value"
-          hint="Calculation of the constant value, use 'text' for a string value, [1,2,3] for a matrix, or 123 for a number"
+          :label="$t('properties.forms.constantForm.value')"
+          :hint="$t('properties.forms.constantForm.valueHint')"
           :value="model.calculation"
           :error-messages="errors.calculation"
           @change="change('calculation', ...arguments)"

--- a/app/imports/client/ui/properties/forms/ContainerForm.vue
+++ b/app/imports/client/ui/properties/forms/ContainerForm.vue
@@ -6,11 +6,11 @@
         md="6"
       >
         <text-field
-          label="Value"
+          :label="$t('properties.forms.containerForm.value')"
           suffix="gp"
           type="number"
           min="0"
-          hint="The value of the item in gold pieces, using decimals for values less than 1 gp"
+          :hint="$t('properties.forms.containerForm.valueHint')"
           class="mx-1"
           style="flex-basis: 300px;"
           prepend-inner-icon="$vuetify.icons.two_coins"
@@ -24,7 +24,7 @@
         md="6"
       >
         <text-field
-          label="Weight"
+          :label="$t('properties.forms.containerForm.weight')"
           suffix="lb"
           type="number"
           min="0"
@@ -41,9 +41,9 @@
         sm="6"
       >
         <smart-switch
-          label="Carried"
+          :label="$t('properties.forms.containerForm.carried')"
           class="mx-3"
-          hint="Whether this container and its contents count towards the creature's weight carried"
+          :hint="$t('properties.forms.containerForm.carriedHint')"
           :value="model.carried"
           :error-messages="errors.carried"
           @change="change('carried', ...arguments)"
@@ -54,7 +54,7 @@
         sm="6"
       >
         <smart-switch
-          label="Contents are weightless"
+          :label="$t('properties.forms.containerForm.contentsWeightless')"
           :value="model.contentsWeightless"
           :error-messages="errors.contentsWeightless"
           @change="change('contentsWeightless', ...arguments)"
@@ -64,7 +64,7 @@
 
     <inline-computation-field
       class="mt-4"
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>

--- a/app/imports/client/ui/properties/forms/DamageForm.vue
+++ b/app/imports/client/ui/properties/forms/DamageForm.vue
@@ -7,8 +7,8 @@
       >
         <computed-field
           ref="focusFirst"
-          label="Damage"
-          hint="A calculation including dice rolls of the damage to deal to the target when activated by an action"
+          :label="$t('properties.forms.damageForm.damage')"
+          :hint="$t('properties.forms.damageForm.damageHint')"
           :model="model.amount"
           :error-messages="errors.amount"
           @change="({path, value, ack}) =>
@@ -20,9 +20,9 @@
         md="6"
       >
         <smart-combobox
-          label="Damage Type"
+          :label="$t('properties.forms.damageForm.damageType')"
           style="flex-basis: 200px;"
-          hint="Use the Healing type to restore hit points"
+          :hint="$t('properties.forms.damageForm.damageTypeHint')"
           :rules="damageTypeRules"
           :items="DAMAGE_TYPES"
           :value="model.damageType"
@@ -33,11 +33,11 @@
       </v-col>
       <v-col cols="12">
         <smart-toggle
-          label="Target creature"
+          :label="$t('properties.forms.damageForm.targetCreature')"
           :value="model.target"
           :options="[
-            {name: 'Action Target', value: 'target'},
-            {name: 'Self', value: 'self'},
+            {name: $t('properties.forms.damageForm.actionTarget'), value: 'target'},
+            {name: $t('properties.forms.damageForm.self'), value: 'self'},
           ]"
           :error-messages="errors.target"
           @change="change('target', ...arguments)"
@@ -46,7 +46,7 @@
       <v-col cols="12">
         <smart-switch
           class="mt-0"
-          label="Saving throw"
+          :label="$t('properties.forms.damageForm.savingThrow')"
           :value="!!model.save"
           :error-messages="errors.save"
           @change="(val, ack) => $emit('change', {
@@ -67,8 +67,8 @@
           md="6"
         >
           <computed-field
-            label="DC"
-            hint="Saving throw DC"
+            :label="$t('properties.forms.damageForm.dc')"
+            :hint="$t('properties.forms.damageForm.dcHint')"
             :model="model.save.dc"
             :error-messages="errors['save.dc']"
             @change="({path, value, ack}) =>
@@ -80,8 +80,8 @@
           md="6"
         >
           <smart-combobox
-            label="Save"
-            hint="Which stat the saving throw targets"
+            :label="$t('properties.forms.damageForm.save')"
+            :hint="$t('properties.forms.damageForm.saveHint')"
             :value="model.save.stat"
             :items="saveList"
             :error-messages="errors['save.stat']"
@@ -92,9 +92,9 @@
         <v-col cols="12">
           <computed-field
             v-if="!!model.save"
-            label="Damage on successful save"
-            hint="Use &quot;~damage&quot; to reference the damage that would normally be dealt"
-            placeholder="Half damage"
+            :label="$t('properties.forms.damageForm.damageOnSuccessfulSave')"
+            :hint="$t('properties.forms.damageForm.damageOnSuccessfulSaveHint')"
+            :placeholder="$t('properties.forms.damageForm.halfDamage')"
             persistent-placeholder
             :model="model.save.damageFunction"
             :error-messages="errors['save.damageFunction']"
@@ -105,11 +105,11 @@
       </v-row>
     </v-expand-transition>
     <form-sections type="damage">
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <v-row>
           <v-col cols="12">
             <smart-switch
-              label="Don't show in log"
+              :label="$t('properties.forms.actionForm.dontShowInLog')"
               :value="model.silent"
               :error-messages="errors.silent"
               @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/properties/forms/DamageMultiplierForm.vue
+++ b/app/imports/client/ui/properties/forms/DamageMultiplierForm.vue
@@ -5,17 +5,17 @@
         cols="12"
       >
         <smart-toggle
-          label="Multiplier"
+          :label="$t('properties.forms.damageMultiplierForm.multiplier')"
           :value="model.value"
           :options="[{
             value: 2,
-            name: 'Vulnerability',
+            name: $t('properties.forms.damageMultiplierForm.vulnerability'),
           },{
             value: 0.5,
-            name: 'Resistance',
+            name: $t('properties.forms.damageMultiplierForm.resistance'),
           }, {
             value: 0,
-            name: 'Immunity',
+            name: $t('properties.forms.damageMultiplierForm.immunity'),
           }]"
           :error-messages="errors.value"
           @change="change('value', ...arguments)"
@@ -25,7 +25,7 @@
     <v-row dense>
       <v-col cols="12">
         <smart-combobox
-          label="Damage Types"
+          :label="$t('properties.forms.damageMultiplierForm.damageTypes')"
           multiple
           chips
           deletable-chips
@@ -42,16 +42,16 @@
     <form-sections type="damageMultiplier">
       <form-section
         v-if="$slots.children"
-        name="Children"
+        :name="$t('properties.forms.damageMultiplierForm.children')"
       >
         <slot name="children" />
       </form-section>
-      <form-section name="Apply by tag">
+      <form-section :name="$t('properties.forms.damageMultiplierForm.applyByTag')">
         <v-row dense>
           <v-col cols="12">
             <smart-combobox
-              label="Tags required"
-              hint="Only apply to damage that has all of these tags"
+              :label="$t('properties.forms.damageMultiplierForm.tagsRequired')"
+              :hint="$t('properties.forms.damageMultiplierForm.tagsRequiredHint')"
               multiple
               small-chips
               deletable-chips
@@ -63,8 +63,8 @@
           </v-col>
           <v-col cols="12">
             <smart-combobox
-              label="Tags excluded"
-              hint="Don't apply to damage that has any of these tags"
+              :label="$t('properties.forms.damageMultiplierForm.tagsExcluded')"
+              :hint="$t('properties.forms.damageMultiplierForm.tagsExcludedHint')"
               multiple
               small-chips
               deletable-chips

--- a/app/imports/client/ui/properties/forms/EffectForm.vue
+++ b/app/imports/client/ui/properties/forms/EffectForm.vue
@@ -6,7 +6,7 @@
         md="6"
       >
         <smart-select
-          label="Operation"
+          :label="$t('properties.forms.effectForm.operation')"
           append-icon="mdi-menu-down"
           :hint="operationHint"
           :error-messages="errors.operation"
@@ -39,16 +39,16 @@
       >
         <text-field
           v-if="model.operation === 'conditional'"
-          label="Text"
-          hint="The text to display on the affected stats"
+          :label="$t('properties.forms.effectForm.text')"
+          :hint="$t('properties.forms.effectForm.textHint')"
           :value="model.text"
           :error-messages="errors.text"
           @change="change('text', ...arguments)"
         />
         <computed-field
           v-else
-          label="Value"
-          hint="Number or calculation to determine the value of this effect"
+          :label="$t('properties.forms.effectForm.value')"
+          :hint="$t('properties.forms.effectForm.valueHint')"
           :disabled="!needsValue"
           :model="model.amount"
           :error-messages="errors.amount"
@@ -59,11 +59,11 @@
     </v-row>
 
     <smart-toggle
-      label="Target properties"
+      :label="$t('properties.forms.effectForm.targetProperties')"
       :value="radioGroup"
       :options="[
-        {name: 'Target by variable name', value: 'stats'},
-        {name: 'Target by tags', value: 'tags'},
+        {name: $t('properties.forms.effectForm.targetByVariableName'), value: 'stats'},
+        {name: $t('properties.forms.effectForm.targetByTags'), value: 'tags'},
       ]"
       @change="changeTargetByTags"
     />
@@ -71,12 +71,12 @@
     <v-slide-y-transition hide-on-leave>
       <smart-combobox
         v-if="!model.targetByTags"
-        label="Stats"
+        :label="$t('properties.forms.effectForm.stats')"
         class="mr-2"
         multiple
         small-chips
         deletable-chips
-        hint="Which stats will this effect apply to"
+        :hint="$t('properties.forms.effectForm.statsHint')"
         persistent-hint
         :value="model.stats"
         :items="attributeList"
@@ -98,9 +98,9 @@
         cols="12"
       >
         <text-field
-          label="Target field"
+          :label="$t('properties.forms.effectForm.targetField')"
           :value="model.targetField"
-          hint="Target a specific calculation field on the affected properties"
+          :hint="$t('properties.forms.effectForm.targetFieldHint')"
           placeholder="Default field"
           persistent-placeholder
           :error-messages="errors.targetField"

--- a/app/imports/client/ui/properties/forms/FeatureForm.vue
+++ b/app/imports/client/ui/properties/forms/FeatureForm.vue
@@ -1,8 +1,8 @@
 <template lang="html">
   <div class="feature-form">
     <inline-computation-field
-      label="Summary"
-      hint="This will appear in the feature card in the character sheet"
+      :label="$t('properties.forms.common.summary')"
+      :hint="$t('properties.forms.featureForm.summaryHint')"
       :model="model.summary"
       :error-messages="errors['summary.text']"
       @change="({path, value, ack}) =>
@@ -10,8 +10,8 @@
     />
 
     <inline-computation-field
-      label="Description"
-      hint="The rest of the description that doesn't fit in the summary goes here"
+      :label="$t('properties.forms.common.description')"
+      :hint="$t('properties.forms.featureForm.descriptionHint')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>

--- a/app/imports/client/ui/properties/forms/FolderForm.vue
+++ b/app/imports/client/ui/properties/forms/FolderForm.vue
@@ -1,16 +1,16 @@
 <template lang="html">
   <div class="folder-form">
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
         $emit('change', {path: ['description', ...path], value, ack})"
     />
     <form-sections type="folder">
-      <form-section name="Grouping">
+      <form-section :name="$t('properties.forms.folderForm.grouping')">
         <smart-switch
-          label="Group children on a card"
+          :label="$t('properties.forms.folderForm.groupChildrenOnCard')"
           :value="model.groupStats"
           :error-messages="errors.groupStats"
           @change="change('groupStats', ...arguments)"
@@ -18,22 +18,22 @@
         <v-expand-transition>
           <div v-if="model.groupStats">
             <smart-switch
-              label="Hide children from their default locations"
+              :label="$t('properties.forms.folderForm.hideChildrenFromDefault')"
               :value="model.hideStatsGroup"
               :error-messages="errors.hideStatsGroup"
               @change="change('hideStatsGroup', ...arguments)"
             />
             <smart-select
               clearable
-              label="Tab"
+              :label="$t('properties.forms.folderForm.tab')"
               :items="[
-                { text: 'Stats Tab', value: 'stats' },
-                { text: 'Features Tab', value: 'features' },
-                { text: 'Actions Tab', value: 'actions' },
-                { text: 'Spells Tab', value: 'spells' },
-                { text: 'Inventory Tab', value: 'inventory' },
-                { text: 'Journal Tab', value: 'journal' },
-                { text: 'Build Tab', value: 'build' },
+                { text: $t('properties.forms.folderForm.statsTab'), value: 'stats' },
+                { text: $t('properties.forms.folderForm.featuresTab'), value: 'features' },
+                { text: $t('properties.forms.folderForm.actionsTab'), value: 'actions' },
+                { text: $t('properties.forms.folderForm.spellsTab'), value: 'spells' },
+                { text: $t('properties.forms.folderForm.inventoryTab'), value: 'inventory' },
+                { text: $t('properties.forms.folderForm.journalTab'), value: 'journal' },
+                { text: $t('properties.forms.folderForm.buildTab'), value: 'build' },
               ]"
               :value="model.tab"
               :error-messages="errors.tab"
@@ -42,7 +42,7 @@
             />
             <smart-select
               clearable
-              label="Location"
+              :label="$t('properties.forms.folderForm.location')"
               :items="locationItems"
               :value="model.location"
               :error-messages="errors.location"

--- a/app/imports/client/ui/properties/forms/ItemForm.vue
+++ b/app/imports/client/ui/properties/forms/ItemForm.vue
@@ -3,7 +3,7 @@
     <div class="layout justify-space-around">
       <div>
         <smart-switch
-          label="Equipped"
+          :label="$t('properties.forms.itemForm.equipped')"
           :value="model.equipped"
           :error-messages="errors.equipped"
           @change="change('equipped', ...arguments)"
@@ -16,7 +16,7 @@
         md="6"
       >
         <text-field
-          label="Quantity"
+          :label="$t('properties.forms.itemForm.quantity')"
           type="number"
           min="0"
           prepend-inner-icon="$vuetify.icons.abacus"
@@ -30,10 +30,10 @@
         md="6"
       >
         <text-field
-          label="Plural name"
+          :label="$t('properties.forms.itemForm.pluralName')"
           :value="model.plural"
           :error-messages="errors.plural"
-          hint="The plural name of your item. If your item's name is 'sword' plural name would be 'swords'"
+          :hint="$t('properties.forms.itemForm.pluralNameHint')"
           @change="change('plural', ...arguments)"
         />
       </v-col>
@@ -43,11 +43,11 @@
         md="6"
       >
         <text-field
-          label="Value"
+          :label="$t('properties.forms.itemForm.value')"
           suffix="gp"
           type="number"
           min="0"
-          hint="The value of the item in gold pieces, using decimals for values less than 1 gp"
+          :hint="$t('properties.forms.itemForm.valueHint')"
           prepend-inner-icon="$vuetify.icons.two_coins"
           :value="model.value"
           :error-messages="errors.value"
@@ -59,12 +59,12 @@
         md="6"
       >
         <text-field
-          label="Weight"
+          :label="$t('properties.forms.itemForm.weight')"
           suffix="lb"
           type="number"
           min="0"
           prepend-inner-icon="$vuetify.icons.weight"
-          hint="The weight of a single item in lbs. Can be a decimal value"
+          :hint="$t('properties.forms.itemForm.weightHint')"
           :value="model.weight"
           :error-messages="errors.weight"
           @change="change('weight', ...arguments)"
@@ -73,7 +73,7 @@
     </v-row>
 
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -82,7 +82,7 @@
 
     <form-sections type="item">
       <form-section
-        name="Behavior"
+        :name="$t('properties.forms.common.behavior')"
       >
         <v-row dense>
           <v-col
@@ -90,7 +90,7 @@
             md="6"
           >
             <smart-switch
-              label="Show increment button"
+              :label="$t('properties.forms.itemForm.showIncrement')"
               :value="model.showIncrement"
               :error-messages="errors.showIncrement"
               @change="change('showIncrement', ...arguments)"
@@ -101,7 +101,7 @@
             md="6"
           >
             <smart-switch
-              label="Don't show in log"
+              :label="$t('properties.forms.actionForm.dontShowInLog')"
               :value="model.silent"
               :error-messages="errors.silent"
               @change="change('silent', ...arguments)"
@@ -110,7 +110,7 @@
         </v-row>
       </form-section>
       <form-section
-        name="Attunement"
+        :name="$t('properties.forms.itemForm.attunement')"
       >
         <v-row dense>
           <v-col
@@ -118,7 +118,7 @@
             md="6"
           >
             <smart-switch
-              label="Requires attunement"
+              :label="$t('properties.forms.itemForm.requiresAttunement')"
               :value="model.requiresAttunement"
               :error-messages="errors.requiresAttunement"
               @change="change('requiresAttunement', ...arguments)"
@@ -131,7 +131,7 @@
               md="6"
             >
               <smart-switch
-                label="Attuned"
+                :label="$t('properties.forms.itemForm.attuned')"
                 :value="model.attuned"
                 :error-messages="errors.attuned"
                 @change="change('attuned', ...arguments)"

--- a/app/imports/client/ui/properties/forms/NoteForm.vue
+++ b/app/imports/client/ui/properties/forms/NoteForm.vue
@@ -1,8 +1,8 @@
 <template lang="html">
   <div class="feature-form">
     <inline-computation-field
-      label="Summary"
-      hint="This will appear in the card in the character sheet"
+      :label="$t('properties.forms.common.summary')"
+      :hint="$t('properties.forms.noteForm.summaryHint')"
       :model="model.summary"
       :error-messages="errors['summary.text']"
       @change="({path, value, ack}) =>
@@ -10,8 +10,8 @@
     />
 
     <inline-computation-field
-      label="Description"
-      hint="Text that does not fit in the summary"
+      :label="$t('properties.forms.common.description')"
+      :hint="$t('properties.forms.noteForm.descriptionHint')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>

--- a/app/imports/client/ui/properties/forms/ProficiencyForm.vue
+++ b/app/imports/client/ui/properties/forms/ProficiencyForm.vue
@@ -6,7 +6,7 @@
         md="6"
       >
         <proficiency-select
-          label="Proficiency"
+          :label="$t('properties.forms.proficiencyForm.proficiency')"
           style="flex-basis: 300px;"
           :clearable="false"
           :value="model.value"
@@ -18,11 +18,11 @@
         md="6"
       >
         <smart-toggle
-          label="Target properties"
+          :label="$t('properties.forms.proficiencyForm.targetProperties')"
           :value="model.targetByTags ? 'tags' : 'skills'"
           :options="[
-            {name: 'Target by variable name', value: 'skills'},
-            {name: 'Target by tags', value: 'tags'},
+            {name: $t('properties.forms.proficiencyForm.targetByVariableName'), value: 'skills'},
+            {name: $t('properties.forms.proficiencyForm.targetByTags'), value: 'tags'},
           ]"
           @change="(val, ack) => {
             if (val === 'skills') val = undefined;
@@ -45,12 +45,12 @@
           />
           <smart-combobox
             v-else
-            label="Skills"
+            :label="$t('properties.forms.proficiencyForm.skills')"
             class="mr-2"
             multiple
             small-chips
             deletable-chips
-            hint="Which skills does this proficiency apply to"
+            :hint="$t('properties.forms.proficiencyForm.skillsHint')"
             :value="model.stats"
             :items="skillList"
             :error-messages="errors.stats"
@@ -64,10 +64,10 @@
           cols="12"
         >
           <text-field
-            label="Target field"
+            :label="$t('properties.forms.proficiencyForm.targetField')"
             :value="model.targetField"
-            hint="Target a specific calculation field on the affected properties"
-            placeholder="Default field"
+            :hint="$t('properties.forms.proficiencyForm.targetFieldHint')"
+            :placeholder="$t('properties.forms.proficiencyForm.defaultField')"
             persistent-placeholder
             :error-messages="errors.targetField"
             @change="change('targetField', ...arguments)"

--- a/app/imports/client/ui/properties/forms/RollForm.vue
+++ b/app/imports/client/ui/properties/forms/RollForm.vue
@@ -6,10 +6,10 @@
         md="6"
       >
         <text-field
-          label="Variable name"
+          :label="$t('properties.forms.common.variableName')"
           :value="model.variableName"
           style="flex-basis: 300px;"
-          hint="Use this name in action formulae to refer to the result of this roll"
+          :hint="$t('properties.forms.rollForm.variableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
@@ -19,8 +19,8 @@
         md="6"
       >
         <computed-field
-          label="Roll"
-          hint="The calculation that will be evaluated when the roll is triggered by an action. The result will be saved as the variable name in the context of the roll."
+          :label="$t('properties.forms.rollForm.roll')"
+          :hint="$t('properties.forms.rollForm.rollHint')"
           :model="model.roll"
           :error-messages="errors.roll"
           @change="({path, value, ack}) =>
@@ -29,9 +29,9 @@
       </v-col>
     </v-row>
     <form-sections type="roll">
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/properties/forms/SavingThrowForm.vue
+++ b/app/imports/client/ui/properties/forms/SavingThrowForm.vue
@@ -6,8 +6,8 @@
         md="6"
       >
         <computed-field
-          label="DC"
-          hint="Saving throw DC"
+          :label="$t('properties.forms.savingThrowForm.dc')"
+          :hint="$t('properties.forms.savingThrowForm.dcHint')"
           :model="model.dc"
           :error-messages="errors.dc"
           @change="({path, value, ack}) =>
@@ -19,8 +19,8 @@
         md="6"
       >
         <smart-combobox
-          label="Save"
-          hint="Which stat the saving throw targets"
+          :label="$t('properties.forms.savingThrowForm.save')"
+          :hint="$t('properties.forms.savingThrowForm.saveHint')"
           :value="model.stat"
           :items="saveList"
           :error-messages="errors.stat"
@@ -31,11 +31,11 @@
         cols="12"
       >
         <smart-toggle
-          label="Target creature"
+          :label="$t('properties.forms.savingThrowForm.targetCreature')"
           :value="model.target"
           :options="[
-            {name: 'Action Target', value: 'target'},
-            {name: 'Self', value: 'self'},
+            {name: $t('properties.forms.savingThrowForm.actionTarget'), value: 'target'},
+            {name: $t('properties.forms.savingThrowForm.self'), value: 'self'},
           ]"
           :error-messages="errors.target"
           @change="change('target', ...arguments)"
@@ -43,9 +43,9 @@
       </v-col>
     </v-row>
     <form-sections type="savingThrow">
-      <form-section name="Log">
+      <form-section :name="$t('properties.forms.common.log')">
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/properties/forms/SkillForm.vue
+++ b/app/imports/client/ui/properties/forms/SkillForm.vue
@@ -6,10 +6,10 @@
         md="6"
       >
         <text-field
-          label="Variable name"
+          :label="$t('properties.forms.common.variableName')"
           :value="model.variableName"
           style="flex-basis: 300px;"
-          hint="Use this name in formulae to reference this skill"
+          :hint="$t('properties.forms.common.variableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
@@ -19,10 +19,10 @@
         md="6"
       >
         <smart-combobox
-          label="Ability"
+          :label="$t('properties.forms.skillForm.ability')"
           :value="model.ability"
           style="flex-basis: 300px;"
-          hint="Which ability is this skill based off of"
+          :hint="$t('properties.forms.skillForm.abilityHint')"
           :items="abilityScoreList"
           :error-messages="errors.ability"
           @change="change('ability', ...arguments)"
@@ -33,7 +33,7 @@
         md="6"
       >
         <smart-select
-          label="Type"
+          :label="$t('properties.forms.skillForm.skillType')"
           clearable
           :items="skillTypes"
           :value="model.skillType"
@@ -45,7 +45,7 @@
       </v-col>
     </v-row>
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -53,14 +53,14 @@
     />
 
     <form-sections type="skill">
-      <form-section name="Base Values">
+      <form-section :name="$t('properties.forms.skillForm.baseValues')">
         <v-row dense>
           <v-col
             cols="12"
             md="6"
           >
             <proficiency-select
-              label="Base Proficiency"
+              :label="$t('properties.forms.skillForm.baseProficiency')"
               :value="model.baseProficiency"
               :error-messages="errors.baseProficiency"
               @change="change('baseProficiency', ...arguments)"
@@ -71,8 +71,8 @@
             md="6"
           >
             <computed-field
-              label="Base Value"
-              hint="This is the value of the skill before effects are applied"
+              :label="$t('properties.forms.common.baseValue')"
+              :hint="$t('properties.forms.skillForm.baseValueHint')"
               :model="model.baseValue"
               :error-messages="errors.baseValue"
               @change="({path, value, ack}) =>
@@ -81,9 +81,9 @@
           </v-col>
         </v-row>
       </form-section>
-      <form-section name="Apply skill">
+      <form-section :name="$t('properties.forms.skillForm.applySkill')">
         <smart-switch
-          label="Apply skill to targeted tags"
+          :label="$t('properties.forms.skillForm.applySkillToTags')"
           :value="model.targetByTags"
           :error-messages="errors.targetByTags"
           @change="change('targetByTags', ...arguments)"

--- a/app/imports/client/ui/properties/forms/SlotForm.vue
+++ b/app/imports/client/ui/properties/forms/SlotForm.vue
@@ -3,10 +3,10 @@
     <v-row dense>
       <v-col cols="12">
         <smart-select
-          label="Type"
+          :label="$t('properties.forms.slotForm.type')"
           clearable
-          hint="What property type is needed to fill this slot"
-          placeholder="Any type"
+          :hint="$t('properties.forms.slotForm.typeHint')"
+          :placeholder="$t('properties.forms.slotForm.anyType')"
           persistent-placeholder
           :items="slotTypes"
           :value="model.slotType"
@@ -32,9 +32,9 @@
         md="6"
       >
         <computed-field
-          label="Quantity"
-          hint="How many matching properties must be used to fill this slot"
-          placeholder="unlimited"
+          :label="$t('properties.forms.slotForm.quantity')"
+          :hint="$t('properties.forms.slotForm.quantityHint')"
+          :placeholder="$t('properties.forms.slotForm.unlimited')"
           persistent-placeholder
           :model="model.quantityExpected"
           :error-messages="errors.quantityExpected"
@@ -47,9 +47,9 @@
         md="6"
       >
         <computed-field
-          label="Condition"
-          hint="A caclulation to determine if this slot should be active"
-          placeholder="Always active"
+          :label="$t('properties.forms.slotForm.condition')"
+          :hint="$t('properties.forms.slotForm.conditionHint')"
+          :placeholder="$t('properties.forms.slotForm.alwaysActive')"
           persistent-placeholder
           :model="model.slotCondition"
           :error-messages="errors.slotCondition"
@@ -63,11 +63,11 @@
       >
         <smart-select
           v-if="model.type !== 'class'"
-          label="Unique"
+          :label="$t('properties.forms.slotForm.unique')"
           style="flex-basis: 300px;"
           clearable
-          hint="Do the properties that fill this slot need to be unique?"
-          placeholder="Allow duplicate values"
+          :hint="$t('properties.forms.slotForm.uniqueHint')"
+          :placeholder="$t('properties.forms.slotForm.allowDuplicates')"
           persistent-placeholder
           :items="uniqueOptions"
           :value="model.unique"
@@ -98,7 +98,7 @@
       </v-col>
     </v-row>
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -106,7 +106,7 @@
     />
 
     <form-sections type="slot">
-      <form-section name="Behavior">
+      <form-section :name="$t('properties.forms.common.behavior')">
         <v-row dense>
           <!--
           <v-col
@@ -128,7 +128,7 @@
             md="6"
           >
             <smart-switch
-              label="Ignored"
+              :label="$t('properties.forms.slotForm.ignored')"
               style="width: 200px; flex-grow: 0;"
               class="mx-2"
               :value="model.ignored"

--- a/app/imports/client/ui/properties/forms/SpellForm.vue
+++ b/app/imports/client/ui/properties/forms/SpellForm.vue
@@ -8,7 +8,7 @@
       >
         <smart-switch
           class="ml-2"
-          label="Always prepared"
+          :label="$t('properties.forms.spellForm.alwaysPrepared')"
           :value="model.alwaysPrepared"
           :error-messages="errors.alwaysPrepared"
           @change="change('alwaysPrepared', ...arguments)"
@@ -22,7 +22,7 @@
       >
         <smart-switch
           class="ml-2"
-          label="Prepared"
+          :label="$t('properties.forms.spellForm.prepared')"
           :value="model.prepared"
           :error-messages="errors.prepared"
           @change="change('prepared', ...arguments)"
@@ -36,7 +36,7 @@
       >
         <smart-switch
           class="ml-2"
-          label="Cast without spell slots"
+          :label="$t('properties.forms.spellForm.castWithoutSpellSlots')"
           :value="model.castWithoutSpellSlots"
           :error-messages="errors.castWithoutSpellSlots"
           @change="change('castWithoutSpellSlots', ...arguments)"
@@ -49,8 +49,8 @@
         md="6"
       >
         <smart-select
-          label="Level"
-          hint="The spell level"
+          :label="$t('properties.forms.spellForm.level')"
+          :hint="$t('properties.forms.spellForm.levelHint')"
           :items="spellLevels"
           :value="model.level"
           :error-messages="errors.level"
@@ -62,7 +62,7 @@
         md="6"
       >
         <smart-select
-          label="School"
+          :label="$t('properties.forms.spellForm.school')"
           :items="magicSchools"
           :value="model.school"
           :error-messages="errors.school"
@@ -74,7 +74,7 @@
         md="6"
       >
         <text-field
-          label="Casting Time"
+          :label="$t('properties.forms.spellForm.castingTime')"
           :value="model.castingTime"
           :error-messages="errors.castingTime"
           @change="change('castingTime', ...arguments)"
@@ -85,7 +85,7 @@
         md="6"
       >
         <text-field
-          label="Range"
+          :label="$t('properties.forms.spellForm.range')"
           :value="model.range"
           :error-messages="errors.range"
           @change="change('range', ...arguments)"
@@ -96,7 +96,7 @@
         md="6"
       >
         <text-field
-          label="Duration"
+          :label="$t('properties.forms.spellForm.duration')"
           :value="model.duration"
           :error-messages="errors.duration"
           @change="change('duration', ...arguments)"
@@ -110,7 +110,7 @@
         class="pt-1"
       >
         <smart-checkbox
-          label="Verbal"
+          :label="$t('properties.forms.spellForm.verbal')"
           :value="model.verbal"
           :error-messages="errors.verbal"
           @change="change('verbal', ...arguments)"
@@ -122,7 +122,7 @@
         class="pt-1"
       >
         <smart-checkbox
-          label="Somatic"
+          :label="$t('properties.forms.spellForm.somatic')"
           :value="model.somatic"
           :error-messages="errors.somatic"
           @change="change('somatic', ...arguments)"
@@ -134,7 +134,7 @@
         class="pt-1"
       >
         <smart-checkbox
-          label="Concentration"
+          :label="$t('properties.forms.spellForm.concentration')"
           :value="model.concentration"
           :error-messages="errors.concentration"
           @change="change('concentration', ...arguments)"
@@ -146,7 +146,7 @@
         class="pt-1"
       >
         <smart-checkbox
-          label="Ritual"
+          :label="$t('properties.forms.spellForm.ritual')"
           :value="model.ritual"
           :error-messages="errors.ritual"
           @change="change('ritual', ...arguments)"
@@ -156,7 +156,7 @@
     <v-row dense>
       <v-col cols="12">
         <text-field
-          label="Material"
+          :label="$t('properties.forms.spellForm.material')"
           :value="model.material"
           :error-messages="errors.material"
           @change="change('material', ...arguments)"
@@ -169,12 +169,12 @@
         md="6"
       >
         <smart-toggle
-          label="Target creature"
+          :label="$t('properties.forms.actionForm.targetCreature')"
           :value="model.target"
           :options="[
-            {name: 'Single Target', value: 'singleTarget'},
-            {name: 'Multiple Targets', value: 'multipleTargets'},
-            {name: 'Self', value: 'self'},
+            {name: $t('properties.forms.actionForm.singleTarget'), value: 'singleTarget'},
+            {name: $t('properties.forms.actionForm.multipleTargets'), value: 'multipleTargets'},
+            {name: $t('properties.forms.actionForm.self'), value: 'self'},
           ]"
           :error-messages="errors.target"
           @change="change('target', ...arguments)"
@@ -217,22 +217,22 @@
       </v-col>
     </v-row>
     <inline-computation-field
-      label="Summary"
-      hint="This will appear in the action card in the character sheet, summarise what the action does"
+      :label="$t('properties.forms.common.summary')"
+      :hint="$t('properties.forms.actionForm.summaryHint')"
       :model="model.summary"
       :error-messages="errors['summary.text']"
       @change="({path, value, ack}) =>
         $emit('change', {path: ['summary', ...path], value, ack})"
     />
     <inline-computation-field
-      label="Description"
+      :label="$t('properties.forms.common.description')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
         $emit('change', {path: ['description', ...path], value, ack})"
     />
     <form-sections type="spell">
-      <form-section name="Resources Consumed">
+      <form-section :name="$t('properties.forms.common.resourcesConsumed')">
         <resources-form
           :model="model.resources"
           @change="({path, value, ack}) => $emit('change', {path: ['resources', ...path], value, ack})"
@@ -241,15 +241,15 @@
         />
       </form-section>
 
-      <form-section name="Limit Uses">
+      <form-section :name="$t('properties.forms.common.limitUses')">
         <v-row dense>
           <v-col
             cols="12"
             md="6"
           >
             <computed-field
-              label="Uses"
-              hint="How many times this action can be used before needing to be reset"
+              :label="$t('properties.forms.common.uses')"
+              :hint="$t('properties.forms.common.usesHint')"
               class="mr-2"
               :model="model.uses"
               :error-messages="errors.uses"
@@ -262,9 +262,9 @@
             md="6"
           >
             <text-field
-              label="Uses used"
+              :label="$t('properties.forms.common.usesUsed')"
               type="number"
-              hint="How many times this action has already been used: should be 0 in most cases"
+              :hint="$t('properties.forms.common.usesUsedHint')"
               style="flex-basis: 300px;"
               :value="model.usesUsed"
               :error-messages="errors.uses"

--- a/app/imports/client/ui/properties/forms/ToggleForm.vue
+++ b/app/imports/client/ui/properties/forms/ToggleForm.vue
@@ -6,9 +6,9 @@
         md="6"
       >
         <text-field
-          label="Variable name"
+          :label="$t('properties.forms.common.variableName')"
           :value="model.variableName"
-          hint="Use this name in calculations to reference this attribute"
+          :hint="$t('properties.forms.common.variableNameHint')"
           :error-messages="errors.variableName"
           @change="change('variableName', ...arguments)"
         />
@@ -19,12 +19,12 @@
         md="6"
       >
         <smart-toggle
-          label="Active"
+          :label="$t('properties.forms.toggleForm.active')"
           :value="radioSelection"
           :options="[
-            {name: 'Enabled', value: 'enabled'},
-            {name: 'Disabled', value: 'disabled'},
-            {name: 'Calculated', value: 'calculated'},
+            {name: $t('properties.forms.toggleForm.enabled'), value: 'enabled'},
+            {name: $t('properties.forms.toggleForm.disabled'), value: 'disabled'},
+            {name: $t('properties.forms.toggleForm.calculated'), value: 'calculated'},
           ]"
           :error-messages="errors.enabled"
           @change="radioChange"
@@ -36,8 +36,8 @@
           cols="12"
         >
           <computed-field
-            label="Condition"
-            hint="When this calculation returns a value that isn't false or zero the children will be active"
+            :label="$t('properties.forms.toggleForm.condition')"
+            :hint="$t('properties.forms.toggleForm.conditionHint')"
             :model="model.condition"
             :error-messages="errors.condition"
             @change="({path, value, ack}) =>
@@ -47,11 +47,11 @@
       </v-expand-transition>
       <v-col cols="12">
         <smart-toggle
-          label="Enabled or disable properties"
+          :label="$t('properties.forms.toggleForm.enableOrDisable')"
           :value="model.targetByTags"
           :options="[
-            {name: 'Descendants', value: false},
-            {name: 'By target tags', value: true},
+            {name: $t('properties.forms.toggleForm.descendants'), value: false},
+            {name: $t('properties.forms.toggleForm.byTargetTags'), value: true},
           ]"
           @change="change('targetByTags', ...arguments)"
         />
@@ -71,14 +71,14 @@
     </v-row>
 
     <form-sections type="toggle">
-      <form-section name="Behavior">
+      <form-section :name="$t('properties.forms.common.behavior')">
         <v-col
           cols="12"
           md="6"
         >
           <smart-switch
             class="ml-2"
-            label="Show on character sheet"
+            :label="$t('properties.forms.toggleForm.showOnCharacterSheet')"
             :value="model.showUI"
             :error-messages="errors.showUI"
             @change="change('showUI', ...arguments)"

--- a/app/imports/client/ui/properties/forms/TriggerForm.vue
+++ b/app/imports/client/ui/properties/forms/TriggerForm.vue
@@ -6,9 +6,9 @@
         md="6"
       >
         <smart-select
-          label="Timing"
+          :label="$t('properties.forms.triggerForm.timing')"
           style="flex-basis: 300px;"
-          hint="When this trigger will fire"
+          :hint="$t('properties.forms.triggerForm.timingHint')"
           :items="timingOptions"
           :value="model.timing"
           :error-messages="errors.timing"
@@ -20,9 +20,9 @@
         md="6"
       >
         <smart-select
-          label="Event"
+          :label="$t('properties.forms.triggerForm.event')"
           style="flex-basis: 300px;"
-          hint="What causes this trigger to fire"
+          :hint="$t('properties.forms.triggerForm.eventHint')"
           :items="eventOptions"
           :value="model.event"
           :error-messages="errors.event"
@@ -34,9 +34,9 @@
         md="6"
       >
         <computed-field
-          label="Condition"
-          hint="A calculation to determine if this trigger should fire"
-          placeholder="Always active"
+          :label="$t('properties.forms.triggerForm.condition')"
+          :hint="$t('properties.forms.triggerForm.conditionHint')"
+          :placeholder="$t('properties.forms.slotForm.alwaysActive')"
           persistent-placeholder
           :model="model.condition"
           :error-messages="errors.condition"
@@ -51,9 +51,9 @@
           md="6"
         >
           <smart-select
-            label="Event Type"
+            :label="$t('properties.forms.triggerForm.eventType')"
             style="flex-basis: 300px;"
-            hint="Which action event causes this trigger to fire"
+            :hint="$t('properties.forms.triggerForm.eventTypeHint')"
             :items="actionPropertyTypeOptions"
             :value="model.actionPropertyType"
             :error-messages="errors.actionPropertyType"
@@ -74,8 +74,8 @@
 
     <inline-computation-field
       class="mt-6"
-      label="Description"
-      hint="The rest of the description that doesn't fit in the summary goes here"
+      :label="$t('properties.forms.common.description')"
+      :hint="$t('properties.forms.featureForm.descriptionHint')"
       :model="model.description"
       :error-messages="errors['description.text']"
       @change="({path, value, ack}) =>
@@ -84,10 +84,10 @@
 
     <form-sections type="trigger">
       <form-section
-        name="Log"
+        :name="$t('properties.forms.common.log')"
       >
         <smart-switch
-          label="Don't show in log"
+          :label="$t('properties.forms.actionForm.dontShowInLog')"
           :value="model.silent"
           :error-messages="errors.silent"
           @change="change('silent', ...arguments)"

--- a/app/imports/client/ui/sharing/ShareDialog.vue
+++ b/app/imports/client/ui/sharing/ShareDialog.vue
@@ -1,24 +1,24 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Sharing
+      {{ $t('share.title') }}
     </v-toolbar-title>
     <div v-if="model">
       <smart-select
-        label="Who can view"
+        :label="$t('share.whoCanView')"
         :items="[
-          {text: 'Only people I share with', value: 'false'},
-          {text: 'Anyone with link', value: 'true'}
+          {text: $t('share.onlyPeopleIShareWith'), value: 'false'},
+          {text: $t('share.anyoneWithLink'), value: 'true'}
         ]"
         :value="!!model.public + ''"
         @change="(value, ack) => setSheetPublic({value, ack})"
       />
       <smart-select
         v-if="docRef.collection === 'libraries'"
-        label="Who can copy from this library"
+        :label="$t('share.whoCanCopy')"
         :items="[
-          {text: 'Only people with edit permission', value: 'false'},
-          {text: 'Anyone with read permission', value: 'true'}
+          {text: $t('share.onlyPeopleWithEditPermission'), value: 'false'},
+          {text: $t('share.anyoneWithReadPermission'), value: 'true'}
         ]"
         :value="!!model.readersCanCopy + ''"
         @change="(value, ack) => setReadersCanCopy({value, ack})"
@@ -34,7 +34,7 @@
       />
       <div class="layout">
         <text-field
-          label="Username or email"
+          :label="$t('share.textFieldPlaceholder')"
           :value="userSearched"
           :debounce-time="300"
           @change="(value, ack) => getUser({value, ack})"
@@ -44,7 +44,7 @@
           :disabled="userFoundState !== 'found'"
           @click="updateSharing(userId, 'reader')"
         >
-          Share
+          {{ $t('share.shareButton') }}
         </v-btn>
       </div>
       <v-list
@@ -60,7 +60,7 @@
               {{ user.username || user._id }}
             </v-list-item-title>
             <v-list-item-subtitle>
-              {{ user.permission === 'writer' ? 'Can edit' : 'Can view' }}
+              {{ user.permission === 'writer' ? $t('share.permission.writer') : $t('share.permission.reader') }}
             </v-list-item-subtitle>
           </v-list-item-content>
           <v-list-item-action>
@@ -85,7 +85,7 @@
                   <v-list-item-action>
                     <v-icon>mdi-pencil</v-icon>
                   </v-list-item-action>
-                  <v-list-item-title>Can edit</v-list-item-title>
+                  <v-list-item-title>{{ $t('share.permission.writer') }}</v-list-item-title>
                 </v-list-item>
                 <v-list-item
                   v-if="user.permission === 'writer'"
@@ -94,7 +94,7 @@
                   <v-list-item-action>
                     <v-icon>mdi-eye</v-icon>
                   </v-list-item-action>
-                  <v-list-item-title>View only</v-list-item-title>
+                  <v-list-item-title>{{ $t('share.permission.reader') }}</v-list-item-title>
                 </v-list-item>
                 <v-list-item
                   v-if="user.permission === 'writer'"
@@ -103,13 +103,13 @@
                   <v-list-item-action>
                     <v-icon>mdi-signature</v-icon>
                   </v-list-item-action>
-                  <v-list-item-title>Transfer Ownership</v-list-item-title>
+                  <v-list-item-title>{{ $t('share.transferOwnership') }}</v-list-item-title>
                 </v-list-item>
                 <v-list-item @click="updateSharing(user._id, 'none')">
                   <v-list-item-action>
                     <v-icon>mdi-delete</v-icon>
                   </v-list-item-action>
-                  <v-list-item-title>Remove</v-list-item-title>
+                  <v-list-item-title>{{ $t('share.remove') }}</v-list-item-title>
                 </v-list-item>
               </v-list>
             </v-menu>
@@ -129,7 +129,7 @@
       text
       @click="$store.dispatch('popDialogStack')"
     >
-      Done
+      {{ $t('share.confirm') }}
     </v-btn>
   </dialog-base>
 </template>

--- a/app/imports/client/ui/sharing/TransferOwnershipDialog.vue
+++ b/app/imports/client/ui/sharing/TransferOwnershipDialog.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Transfer Ownership
+      {{ $t('transferOwnershipDialog.title') }}
     </v-toolbar-title>
     <v-alert
       type="error"
@@ -14,11 +14,11 @@
       </template>
       <template v-else>
         <p>
-          Are you sure you want to transfer ownership to {{ user.username || user._id }}?
+          {{ $t('transferOwnershipDialog.areYouSure') }} {{ user.username || user._id }}?
         </p><p>
-          This can only be undone by the user you are transferring ownership to.
+          {{ $t('transferOwnershipDialog.thisCannotBeUndone') }}
         </p><p>
-          You will still have edit permission.
+          {{ $t('transferOwnershipDialog.youEditPermission') }}
         </p>
       </template>
     </v-alert>
@@ -27,9 +27,9 @@
         color="accent"
         @click="transfer"
       >
-        Transfer
+        {{ $t('transferOwnershipDialog.confirm') }}
         <template v-if="user.username">
-          to {{ user.username }}
+          {{ user.username }}
         </template>
       </v-btn>
     </v-layout>

--- a/app/imports/client/ui/tabletop/CharacterSheetDialog.vue
+++ b/app/imports/client/ui/tabletop/CharacterSheetDialog.vue
@@ -25,31 +25,31 @@
       )"
     >
       <v-btn>
-        <span>Stats</span>
+        <span>{{ $t('character.stats') }}</span>
         <v-icon>mdi-chart-box</v-icon>
       </v-btn>
       <v-btn>
-        <span>Actions</span>
+        <span>{{ $t('character.actions') }}</span>
         <v-icon>mdi-lightning-bolt</v-icon>
       </v-btn>
       <v-btn v-if="!creature.settings.hideSpellsTab">
-        <span>Spells</span>
+        <span>{{ $t('character.spells') }}</span>
         <v-icon>mdi-fire</v-icon>
       </v-btn>
       <v-btn>
-        <span>Inventory</span>
+        <span>{{ $t('character.inventory') }}</span>
         <v-icon>mdi-cube</v-icon>
       </v-btn>
       <v-btn>
-        <span>Features</span>
+        <span>{{ $t('character.features') }}</span>
         <v-icon>mdi-text</v-icon>
       </v-btn>
       <v-btn>
-        <span>Journal</span>
+        <span>{{ $t('character.journal') }}</span>
         <v-icon>mdi-book-open-variant</v-icon>
       </v-btn>
       <v-btn>
-        <span>Build</span>
+        <span>{{ $t('character.build') }}</span>
         <v-icon>mdi-wrench</v-icon>
       </v-btn>
     </v-bottom-navigation>

--- a/app/imports/client/ui/tabletop/TabletopComponent.vue
+++ b/app/imports/client/ui/tabletop/TabletopComponent.vue
@@ -54,7 +54,7 @@
             <v-icon left>
               mdi-plus
             </v-icon>
-            Add Character
+            {{ $t('tabletop.addCharacter') }}
           </v-btn>
           <v-btn
             data-id="creatures-from-library"
@@ -63,7 +63,7 @@
             <v-icon left>
               mdi-plus
             </v-icon>
-            Add Creature
+            {{ $t('tabletop.addCreature') }}
           </v-btn>
         </div>
       </v-row>

--- a/app/imports/client/ui/tabletop/TabletopForm.vue
+++ b/app/imports/client/ui/tabletop/TabletopForm.vue
@@ -6,7 +6,7 @@
         md="6"
       >
         <text-field
-          label="Name"
+          :label="$t('pages.tabletop.name')"
           :value="model.name"
           :error-messages="errors.name"
           :disabled="!editPermission"
@@ -18,8 +18,8 @@
         md="6"
       >
         <smart-image-input
-          label="Picture URL"
-          hint="A link to a cover image for this tabletop"
+          :label="$t('pages.tabletop.pictureUrl')"
+          :hint="$t('pages.tabletop.pictureUrlHint')"
           :disabled="!editPermission"
           :value="model.imageUrl"
           :error-messages="errors.imageUrl"
@@ -30,7 +30,7 @@
         cols="12"
       >
         <text-area
-          label="Description"
+          :label="$t('pages.tabletop.description')"
           :value="model.description"
           :disabled="!editPermission"
           @change="(value, ack) => change('description', value, ack)"
@@ -39,17 +39,17 @@
     </v-row>
 
     <form-sections type="tabletop">
-      <form-section name="Sharing">
+      <form-section :name="$t('pages.tabletop.sharing')">
         <v-row>
           <v-col
             cols="12"
             md="6"
           >
             <smart-select
-              label="Who can view"
+              :label="$t('pages.tabletop.whoCanView')"
               :items="[
-                {text: 'Only people I share with', value: 'false'},
-                {text: 'Anyone with link', value: 'true'}
+                {text: $t('pages.tabletop.onlyPeopleIShareWith'), value: 'false'},
+                {text: $t('pages.tabletop.anyoneWithLink'), value: 'true'}
               ]"
               :value="!!model.public + ''"
               @change="(value, ack) => change('public', value === 'true', ack)"
@@ -62,7 +62,7 @@
           >
             <text-field
               readonly
-              label="Link"
+              :label="$t('pages.tabletop.link')"
               :value="link"
             />
           </v-col>
@@ -72,21 +72,21 @@
             class="mb-4 px-4"
           >
             <h3 class="mb-4">
-              Add user
+              {{ $t('pages.tabletop.addUser') }}
             </h3>
             <text-field
-              label="Username or email"
+              :label="$t('pages.tabletop.usernameOrEmail')"
               :value="userSearched"
               :debounce-time="300"
               :disabled="!editPermission"
               @change="(value, ack) => getUser({value, ack})"
             />
             <smart-select
-              label="Permission"
+              :label="$t('pages.tabletop.permission')"
               :items="[
-                {text: 'Game Master', value: 'gameMaster'},
-                {text: 'Player', value: 'player'},
-                {text: 'Spectator', value: 'spectator'},
+                {text: $t('pages.tabletop.gameMaster'), value: 'gameMaster'},
+                {text: $t('pages.tabletop.player'), value: 'player'},
+                {text: $t('pages.tabletop.spectator'), value: 'spectator'},
               ]"
               :value="newSharePermission"
               :disabled="!editPermission"
@@ -98,12 +98,12 @@
               :disabled="userFoundState !== 'found' || !editPermission"
               @click="ack => updateSharing(userId, newSharePermission, ack)"
             >
-              Share
+              {{ $t('pages.tabletop.share') }}
             </smart-btn>
           </v-col>
 
           <property-field
-            name="Owner"
+            :name="$t('pages.tabletop.owner')"
             :cols="{cols: 12, md: 6}"
           >
             {{ users.owner.username || users.owner._id || '' }}
@@ -115,7 +115,7 @@
             md="6"
             class="mb-4"
           >
-            <outlined-input name="Game Masters">
+            <outlined-input :name="$t('pages.tabletop.gameMasters')">
               <tabletop-user-list
                 :users="users.gameMasters"
                 :edit-permission="editPermission"
@@ -133,7 +133,7 @@
             md="6"
             class="mb-4"
           >
-            <outlined-input name="Players">
+            <outlined-input :name="$t('pages.tabletop.players')">
               <tabletop-user-list
                 :users="users.players"
                 :edit-permission="editPermission"
@@ -151,7 +151,7 @@
             md="6"
             class="mb-4"
           >
-            <outlined-input name="Spectators">
+            <outlined-input :name="$t('pages.tabletop.spectators')">
               <tabletop-user-list
                 :users="users.spectators"
                 :edit-permission="editPermission"
@@ -243,20 +243,20 @@ export default {
           if (result) {
             if (this.users.gameMasters.includes(result)) {
               this.userFoundState = 'failed';
-              ack('User is already a game master');
+              ack(this.$t('pages.tabletop.userAlreadyGameMaster'));
             } else if (this.users.players.includes(result)) {
               this.userFoundState = 'failed';
-              ack('User is already a player');
+              ack(this.$t('pages.tabletop.userAlreadyPlayer'));
             } else if (this.users.spectators.includes(result)) {
               this.userFoundState = 'failed';
-              ack('User is already a spectator');
+              ack(this.$t('pages.tabletop.userAlreadySpectator'));
             } else {
               this.userFoundState = 'found';
               ack();
             }
           } else {
             this.userFoundState = 'notFound';
-            ack('User not found');
+            ack(this.$t('pages.tabletop.userNotFound'));
           }
         }
       });

--- a/app/imports/client/ui/user/DeleteUserAccountDialog.vue
+++ b/app/imports/client/ui/user/DeleteUserAccountDialog.vue
@@ -1,20 +1,20 @@
 <template lang="html">
   <dialog-base>
     <v-toolbar-title slot="toolbar">
-      Delete User Account
+      {{ $t('pages.user.deleteUserAccount') }}
     </v-toolbar-title>
     <div>
-      <h2>Are you sure you want to delete your account?</h2>
+      <h2>{{ $t('pages.user.areYouSure') }}</h2>
       <v-alert
         :value="true"
         icon="mdi-alert"
         color="error"
         outlined
       >
-        Deleted accounts can not be recovered
+        {{ $t('pages.user.deletedAccountsCannotBeRecovered') }}
       </v-alert>
-      <p>We will immediately delete your account and all of your data</p>
-      <p>Your username will become available to anyone on DiceCloud</p>
+      <p>{{ $t('pages.user.immediatelyDeleteData') }}</p>
+      <p>{{ $t('pages.user.usernameWillBeAvailable') }}</p>
       <template v-if="characters.length">
         <h3 v-if="characters.length > 1">
           These {{ characters.length }} characters will be deleted:
@@ -52,14 +52,14 @@
         <v-text-field
           v-if="user.username"
           v-model="usernameInput"
-          label="Type your username or email"
+          :label="$t('pages.user.typeUsernameOrEmail')"
           style="width: 350px;"
           :error-messages="usernameInputValid ? undefined : ' '"
           :append-icon="usernameInputValid ? 'mdi-check' : undefined"
         />
         <v-text-field
           v-model="verificationInput"
-          label="To verify type 'delete my account'"
+          :label="$t('pages.user.toVerifyType')"
           style="width: 350px;"
           :error-messages="verificationInputValid ? undefined : ' '"
           :append-icon="verificationInputValid ? 'mdi-check' : undefined"
@@ -70,7 +70,7 @@
           :disabled="!valid"
           @click="deleteAccount"
         >
-          Permanently delete account
+          {{ $t('pages.user.permanentlyDeleteAccount') }}
         </v-btn>
       </v-layout>
     </div>
@@ -82,7 +82,7 @@
         text
         @click="$store.dispatch('popDialogStack')"
       >
-        Cancel
+          {{ $t('pages.user.cancel') }}
       </v-btn>
     </div>
   </dialog-base>

--- a/app/imports/client/ui/user/UsernameDialog.vue
+++ b/app/imports/client/ui/user/UsernameDialog.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <dialog-base>
     <text-field
-      label="Username"
+      :label="$t('pages.user.username')"
       :value="newUsername || username"
       @change="change"
     />
@@ -19,7 +19,7 @@
       :loading="loading"
       @click="setUsername"
     >
-      Update
+      {{ $t('pages.user.update') }}
     </v-btn>
   </dialog-base>
 </template>
@@ -54,7 +54,7 @@ export default {
           ack(error.message || error);
         } else if (result){
           this.valid = false;
-          ack('Username is already taken');
+          ack(this.$t('pages.user.usernameAlreadyTaken'));
         } else {
           this.valid = true;
           this.newUsername = username;

--- a/app/imports/client/ui/vueSetup.js
+++ b/app/imports/client/ui/vueSetup.js
@@ -8,6 +8,7 @@ import router from '/imports/client/ui/router';
 import '/imports/client/ui/components/global/globalIndex';
 import '/imports/client/ui/markdownCofig';
 import vuetify from '/imports/client/ui/vuetify';
+import i18n from '/imports/client/ui/i18n';
 
 Vue.use(VueMeteorTracker);
 Vue.config.meteor.freeze = true;
@@ -24,6 +25,7 @@ Meteor.startup(() => {
     router,
     store,
     vuetify,
+    i18n,
     ...AppLayout,
   }).$mount('#app');
 });

--- a/app/imports/server/publications/users.js
+++ b/app/imports/server/publications/users.js
@@ -10,6 +10,7 @@ Meteor.publish('user', function () {
         username: 1,
         apiKey: 1,
         darkMode: 1,
+        language: 1,
         subscribedLibraries: 1,
         subscribedLibraryCollections: 1,
         fileStorageUsed: 1,

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,63 +1,130 @@
 {
   "name": "dicecloud",
   "version": "2.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@aws-crypto/crc32": {
+  "packages": {
+    "": {
+      "name": "dicecloud",
+      "version": "2.1.0",
+      "license": "GPL-3.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.523.0",
+        "@babel/runtime": "^7.23.9",
+        "@chenfengyuan/vue-countdown": "^1.1.5",
+        "@tozd/vue-observer-utils": "^0.5.0",
+        "alea": "^1.0.1",
+        "bcrypt": "^5.1.1",
+        "chroma-js": "^2.4.2",
+        "css-box-shadow": "^1.0.0-3",
+        "cytoscape": "^3.28.1",
+        "cytoscape-dagre": "^2.5.0",
+        "cytoscape-klay": "^3.1.4",
+        "dagre": "^0.8.5",
+        "date-fns": "^1.30.1",
+        "ddp-rate-limiter-mixin": "^1.1.10",
+        "discord.js": "^12.5.3",
+        "dompurify": "^2.4.7",
+        "ignore": "^5.3.1",
+        "ignore-styles": "^5.0.1",
+        "lodash": "^4.17.20",
+        "marked": "^4.3.0",
+        "meteor-node-stubs": "^1.2.7",
+        "minify-css-string": "^1.0.0",
+        "moo": "^0.5.2",
+        "nearley": "^2.19.1",
+        "ngraph.graph": "^19.1.0",
+        "ngraph.path": "^1.5.0",
+        "pretty-bytes": "^6.1.1",
+        "qrcode.vue": "^1.7.0",
+        "request": "^2.88.2",
+        "sharp": "^0.33.2",
+        "simpl-schema": "^1.13.1",
+        "source-map-support": "^0.5.21",
+        "speakingurl": "^14.0.1",
+        "thumbhash": "^0.1.1",
+        "type-fest": "^4.32.0",
+        "vivagraphjs": "^0.12.0",
+        "vue": "2.6.14",
+        "vue-i18n": "^8.28.2",
+        "vue-meteor-tracker": "^2.0.0",
+        "vue-reactive-provide": "^0.3.0",
+        "vue-router": "^3.6.5",
+        "vuedraggable": "^2.23.2",
+        "vuetify": "2.6.15",
+        "vuetify-upload-button": "^2.0.2",
+        "vuex": "^3.1.3"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.3.11",
+        "@types/lodash": "^4.14.202",
+        "@types/meteor": "^2.9.8",
+        "@types/meteor-mdg-validated-method": "^1.2.10",
+        "@types/mocha": "^10.0.6",
+        "@types/simpl-schema": "^1.12.7",
+        "@typescript-eslint/eslint-plugin": "^5.62.0",
+        "@typescript-eslint/parser": "^5.62.0",
+        "@vue/compiler-dom": "^3.4.19",
+        "@vue/runtime-dom": "^3.4.19",
+        "chai": "^4.4.1",
+        "eslint": "^7.32.0",
+        "eslint-plugin-vue": "^7.20.0",
+        "eslint-plugin-vuetify": "^1.1.0",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": "14.0.x",
+        "npm": "6.13.x"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
-    "@aws-crypto/crc32c": {
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/crc32c": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
       "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
-    "@aws-crypto/ie11-detection": {
+    "node_modules/@aws-crypto/crc32c/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^1.11.1"
       }
     },
-    "@aws-crypto/sha1-browser": {
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
       "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/supports-web-crypto": "^3.0.0",
         "@aws-crypto/util": "^3.0.0",
@@ -65,20 +132,18 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
-    "@aws-crypto/sha256-browser": {
+    "node_modules/@aws-crypto/sha1-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
         "@aws-crypto/sha256-js": "^3.0.0",
         "@aws-crypto/supports-web-crypto": "^3.0.0",
@@ -87,71 +152,63 @@
         "@aws-sdk/util-locate-window": "^3.0.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
-    "@aws-crypto/sha256-js": {
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/util": "^3.0.0",
         "@aws-sdk/types": "^3.222.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
-    "@aws-crypto/supports-web-crypto": {
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-      "requires": {
-        "tslib": "^1.11.1"
-      },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "tslib": "^1.11.1"
       }
     },
-    "@aws-crypto/util": {
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
       }
     },
-    "@aws-sdk/client-cognito-identity": {
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.540.0.tgz",
       "integrity": "sha512-03vUaIKjvdcOmjDi8Fv9JgY+VQrt9QBpRkI8A1lrdPNgWqTEZXZi/zBsFRsxTe6hgsrZtxVnxLu6krSRILuqtw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/client-sts": "3.540.0",
@@ -193,99 +250,121 @@
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
-          "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "@smithy/util-utf8": "^2.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-browser": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
-          "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-node": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
-          "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/client-s3": {
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.523.0.tgz",
       "integrity": "sha512-d8kFgZpdHOCLtv38nNkItTs3Ew+Ui/YadkCprvbY0boCrFZFTynficFM4orVk+fV3beJ2qVeJm6t8t14V5TaVA==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
@@ -345,727 +424,886 @@
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.5.0"
       },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.523.0.tgz",
+      "integrity": "sha512-vob/Tk9bIr6VIyzScBWsKpP92ACI6/aOXBL2BITgvRWl5Umqi1jXFtfssj/N2UJHM4CBMRwxIJ33InfN0gPxZw==",
       "dependencies": {
-        "@aws-sdk/client-sso": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.523.0.tgz",
-          "integrity": "sha512-vob/Tk9bIr6VIyzScBWsKpP92ACI6/aOXBL2BITgvRWl5Umqi1jXFtfssj/N2UJHM4CBMRwxIJ33InfN0gPxZw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/core": "3.523.0",
-            "@aws-sdk/middleware-host-header": "3.523.0",
-            "@aws-sdk/middleware-logger": "3.523.0",
-            "@aws-sdk/middleware-recursion-detection": "3.523.0",
-            "@aws-sdk/middleware-user-agent": "3.523.0",
-            "@aws-sdk/region-config-resolver": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@aws-sdk/util-endpoints": "3.523.0",
-            "@aws-sdk/util-user-agent-browser": "3.523.0",
-            "@aws-sdk/util-user-agent-node": "3.523.0",
-            "@smithy/config-resolver": "^2.1.3",
-            "@smithy/core": "^1.3.4",
-            "@smithy/fetch-http-handler": "^2.4.3",
-            "@smithy/hash-node": "^2.1.3",
-            "@smithy/invalid-dependency": "^2.1.3",
-            "@smithy/middleware-content-length": "^2.1.3",
-            "@smithy/middleware-endpoint": "^2.4.3",
-            "@smithy/middleware-retry": "^2.1.3",
-            "@smithy/middleware-serde": "^2.1.3",
-            "@smithy/middleware-stack": "^2.1.3",
-            "@smithy/node-config-provider": "^2.2.3",
-            "@smithy/node-http-handler": "^2.4.1",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/smithy-client": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/url-parser": "^2.1.3",
-            "@smithy/util-base64": "^2.1.1",
-            "@smithy/util-body-length-browser": "^2.1.1",
-            "@smithy/util-body-length-node": "^2.2.1",
-            "@smithy/util-defaults-mode-browser": "^2.1.3",
-            "@smithy/util-defaults-mode-node": "^2.2.2",
-            "@smithy/util-endpoints": "^1.1.3",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-retry": "^2.1.3",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.523.0.tgz",
-          "integrity": "sha512-OktkdiuJ5DtYgNrJlo53Tf7pJ+UWfOt7V7or0ije6MysLP18GwlTkbg2UE4EUtfOxt/baXxHMlExB1vmRtlATw==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/client-sts": "3.523.0",
-            "@aws-sdk/core": "3.523.0",
-            "@aws-sdk/middleware-host-header": "3.523.0",
-            "@aws-sdk/middleware-logger": "3.523.0",
-            "@aws-sdk/middleware-recursion-detection": "3.523.0",
-            "@aws-sdk/middleware-user-agent": "3.523.0",
-            "@aws-sdk/region-config-resolver": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@aws-sdk/util-endpoints": "3.523.0",
-            "@aws-sdk/util-user-agent-browser": "3.523.0",
-            "@aws-sdk/util-user-agent-node": "3.523.0",
-            "@smithy/config-resolver": "^2.1.3",
-            "@smithy/core": "^1.3.4",
-            "@smithy/fetch-http-handler": "^2.4.3",
-            "@smithy/hash-node": "^2.1.3",
-            "@smithy/invalid-dependency": "^2.1.3",
-            "@smithy/middleware-content-length": "^2.1.3",
-            "@smithy/middleware-endpoint": "^2.4.3",
-            "@smithy/middleware-retry": "^2.1.3",
-            "@smithy/middleware-serde": "^2.1.3",
-            "@smithy/middleware-stack": "^2.1.3",
-            "@smithy/node-config-provider": "^2.2.3",
-            "@smithy/node-http-handler": "^2.4.1",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/smithy-client": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/url-parser": "^2.1.3",
-            "@smithy/util-base64": "^2.1.1",
-            "@smithy/util-body-length-browser": "^2.1.1",
-            "@smithy/util-body-length-node": "^2.2.1",
-            "@smithy/util-defaults-mode-browser": "^2.1.3",
-            "@smithy/util-defaults-mode-node": "^2.2.2",
-            "@smithy/util-endpoints": "^1.1.3",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-retry": "^2.1.3",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.523.0.tgz",
-          "integrity": "sha512-ggAkL8szaJkqD8oOsS68URJ9XMDbLA/INO/NPZJqv9BhmftecJvfy43uUVWGNs6n4YXNzfF0Y+zQ3DT0fZkv9g==",
-          "requires": {
-            "@aws-crypto/sha256-browser": "3.0.0",
-            "@aws-crypto/sha256-js": "3.0.0",
-            "@aws-sdk/core": "3.523.0",
-            "@aws-sdk/middleware-host-header": "3.523.0",
-            "@aws-sdk/middleware-logger": "3.523.0",
-            "@aws-sdk/middleware-recursion-detection": "3.523.0",
-            "@aws-sdk/middleware-user-agent": "3.523.0",
-            "@aws-sdk/region-config-resolver": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@aws-sdk/util-endpoints": "3.523.0",
-            "@aws-sdk/util-user-agent-browser": "3.523.0",
-            "@aws-sdk/util-user-agent-node": "3.523.0",
-            "@smithy/config-resolver": "^2.1.3",
-            "@smithy/core": "^1.3.4",
-            "@smithy/fetch-http-handler": "^2.4.3",
-            "@smithy/hash-node": "^2.1.3",
-            "@smithy/invalid-dependency": "^2.1.3",
-            "@smithy/middleware-content-length": "^2.1.3",
-            "@smithy/middleware-endpoint": "^2.4.3",
-            "@smithy/middleware-retry": "^2.1.3",
-            "@smithy/middleware-serde": "^2.1.3",
-            "@smithy/middleware-stack": "^2.1.3",
-            "@smithy/node-config-provider": "^2.2.3",
-            "@smithy/node-http-handler": "^2.4.1",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/smithy-client": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/url-parser": "^2.1.3",
-            "@smithy/util-base64": "^2.1.1",
-            "@smithy/util-body-length-browser": "^2.1.1",
-            "@smithy/util-body-length-node": "^2.2.1",
-            "@smithy/util-defaults-mode-browser": "^2.1.3",
-            "@smithy/util-defaults-mode-node": "^2.2.2",
-            "@smithy/util-endpoints": "^1.1.3",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-retry": "^2.1.3",
-            "@smithy/util-utf8": "^2.1.1",
-            "fast-xml-parser": "4.2.5",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/core": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.523.0.tgz",
-          "integrity": "sha512-JHa3ngEWkTzZ2YTn6EavcADC8gv6zZU4U9WBAleClh6ioXH0kGMBawZje3y0F0mKyLTfLhFqFUlCV5sngI/Qcw==",
-          "requires": {
-            "@smithy/core": "^1.3.4",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/signature-v4": "^2.1.3",
-            "@smithy/smithy-client": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.523.0.tgz",
-          "integrity": "sha512-Y6DWdH6/OuMDoNKVzZlNeBc6f1Yjk1lYMjANKpIhMbkRCvLJw/PYZKOZa8WpXbTYdgg9XLjKybnLIb3ww3uuzA==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.523.0.tgz",
-          "integrity": "sha512-6YUtePbn3UFpY9qfVwHFWIVnFvVS5vsbGxxkTO02swvZBvVG4sdG0Xj0AbotUNQNY9QTCN7WkhwIrd50rfDQ9Q==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/fetch-http-handler": "^2.4.3",
-            "@smithy/node-http-handler": "^2.4.1",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/smithy-client": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-stream": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.523.0.tgz",
-          "integrity": "sha512-dRch5Ts67FFRZY5r9DpiC3PM6BVHv1tRcy1b26hoqfFkxP9xYH3dsTSPBog1azIqaJa2GcXqEvKCqhghFTt4Xg==",
-          "requires": {
-            "@aws-sdk/client-sts": "3.523.0",
-            "@aws-sdk/credential-provider-env": "3.523.0",
-            "@aws-sdk/credential-provider-process": "3.523.0",
-            "@aws-sdk/credential-provider-sso": "3.523.0",
-            "@aws-sdk/credential-provider-web-identity": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/credential-provider-imds": "^2.2.3",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.523.0.tgz",
-          "integrity": "sha512-0aW5ylA8pZmvv/8qA/+iel4acEyzSlHRiaHYL3L0qu9SSoe2a92+RHjrxKl6+Sb55eA2mRfQjaN8oOa5xiYyKA==",
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.523.0",
-            "@aws-sdk/credential-provider-http": "3.523.0",
-            "@aws-sdk/credential-provider-ini": "3.523.0",
-            "@aws-sdk/credential-provider-process": "3.523.0",
-            "@aws-sdk/credential-provider-sso": "3.523.0",
-            "@aws-sdk/credential-provider-web-identity": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/credential-provider-imds": "^2.2.3",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.523.0.tgz",
-          "integrity": "sha512-f0LP9KlFmMvPWdKeUKYlZ6FkQAECUeZMmISsv6NKtvPCI9e4O4cLTeR09telwDK8P0HrgcRuZfXM7E30m8re0Q==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.523.0.tgz",
-          "integrity": "sha512-/VfOJuI8ImV//W4gr+yieF/4shzWAzWYeaaNu7hv161C5YW7/OoCygwRVHSnF4KKeUGQZomZWwml5zHZ57f8xQ==",
-          "requires": {
-            "@aws-sdk/client-sso": "3.523.0",
-            "@aws-sdk/token-providers": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.523.0.tgz",
-          "integrity": "sha512-EyBwVoTNZrhLRIHly3JnLzy86deT2hHGoxSCrT3+cVcF1Pq3FPp6n9fUkHd6Yel+wFrjpXCRggLddPvajUoXtQ==",
-          "requires": {
-            "@aws-sdk/client-sts": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.523.0.tgz",
-          "integrity": "sha512-4g3q7Ta9sdD9TMUuohBAkbx/e3I/juTqfKi7TPgP+8jxcYX72MOsgemAMHuP6CX27eyj4dpvjH+w4SIVDiDSmg==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.523.0.tgz",
-          "integrity": "sha512-PeDNJNhfiaZx54LBaLTXzUaJ9LXFwDFFIksipjqjvxMafnoVcQwKbkoPUWLe5ytT4nnL1LogD3s55mERFUsnwg==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.523.0.tgz",
-          "integrity": "sha512-nZ3Vt7ehfSDYnrcg/aAfjjvpdE+61B3Zk68i6/hSUIegT3IH9H1vSW67NDKVp+50hcEfzWwM2HMPXxlzuyFyrw==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.523.0.tgz",
-          "integrity": "sha512-5OoKkmAPNaxLgJuS65gByW1QknGvvXdqzrIMXLsm9LjbsphTOscyvT439qk3Jf08TL4Zlw2x+pZMG7dZYuMAhQ==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@aws-sdk/util-endpoints": "3.523.0",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/region-config-resolver": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.523.0.tgz",
-          "integrity": "sha512-IypIAecBc8b4jM0uVBEj90NYaIsc0vuLdSFyH4LPO7is4rQUet4CkkD+S036NvDdcdxBsQ4hJZBmWrqiizMHhQ==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/node-config-provider": "^2.2.3",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-config-provider": "^2.2.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.523.0.tgz",
-          "integrity": "sha512-m3sPEnLuGV3JY9A8ytcz90SogVtjxEyIxUDFeswxY4C5wP/36yOq3ivenRu07dH+QIJnBhsQdjnHwJfrIetG6g==",
-          "requires": {
-            "@aws-sdk/client-sso-oidc": "3.523.0",
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.523.0.tgz",
-          "integrity": "sha512-f4qe4AdafjAZoVGoVt69Jb2rXCgo306OOobSJ/f4bhQ0zgAjGELKJATNRRe0J7P28+ffmSxeuYwM3r4gDkD/QA==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-endpoints": "^1.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.523.0.tgz",
-          "integrity": "sha512-6ZRNdGHX6+HQFqTbIA5+i8RWzxFyxsZv8D3soRfpdyWIKkzhSz8IyRKXRciwKBJDaC7OX2jzGE90wxRQft27nA==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/types": "^2.10.1",
-            "bowser": "^2.11.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.523.0.tgz",
-          "integrity": "sha512-tW7vliJ77EsE8J1bzFpDYCiUyrw2NTcem+J5ddiWD4HA/xNQUyX0CMOXMBZCBA31xLTIchyz0LkZHlDsmB9LUw==",
-          "requires": {
-            "@aws-sdk/types": "3.523.0",
-            "@smithy/node-config-provider": "^2.2.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/abort-controller": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
-          "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/config-resolver": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.4.tgz",
-          "integrity": "sha512-AW2WUZmBAzgO3V3ovKtsUbI3aBNMeQKFDumoqkNxaVDWF/xfnxAWqBKDr/NuG7c06N2Rm4xeZLPiJH/d+na0HA==",
-          "requires": {
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-config-provider": "^2.2.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/core": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.5.tgz",
-          "integrity": "sha512-Rrc+e2Jj6Gu7Xbn0jvrzZlSiP2CZocIOfZ9aNUA82+1sa6GBnxqL9+iZ9EKHeD9aqD1nU8EK4+oN2EiFpSv7Yw==",
-          "requires": {
-            "@smithy/middleware-endpoint": "^2.4.4",
-            "@smithy/middleware-retry": "^2.1.4",
-            "@smithy/middleware-serde": "^2.1.3",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/smithy-client": "^2.4.2",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/credential-provider-imds": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.4.tgz",
-          "integrity": "sha512-DdatjmBZQnhGe1FhI8gO98f7NmvQFSDiZTwC3WMvLTCKQUY+Y1SVkhJqIuLu50Eb7pTheoXQmK+hKYUgpUWsNA==",
-          "requires": {
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "@smithy/url-parser": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/eventstream-codec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-          "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
-          "requires": {
-            "@aws-crypto/crc32": "3.0.0",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/fetch-http-handler": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
-          "integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
-          "requires": {
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/querystring-builder": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-base64": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/hash-node": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.3.tgz",
-          "integrity": "sha512-FsAPCUj7VNJIdHbSxMd5uiZiF20G2zdSDgrgrDrHqIs/VMxK85Vqk5kMVNNDMCZmMezp6UKnac0B4nAyx7HJ9g==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-buffer-from": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/invalid-dependency": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.3.tgz",
-          "integrity": "sha512-wkra7d/G4CbngV4xsjYyAYOvdAhahQje/WymuQdVEnXFExJopEu7fbL5AEAlBPgWHXwu94VnCSG00gVzRfExyg==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-content-length": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.3.tgz",
-          "integrity": "sha512-aJduhkC+dcXxdnv5ZpM3uMmtGmVFKx412R1gbeykS5HXDmRU6oSsyy2SoHENCkfOGKAQOjVE2WVqDJibC0d21g==",
-          "requires": {
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-endpoint": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
-          "integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
-          "requires": {
-            "@smithy/middleware-serde": "^2.1.3",
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/shared-ini-file-loader": "^2.3.4",
-            "@smithy/types": "^2.10.1",
-            "@smithy/url-parser": "^2.1.3",
-            "@smithy/util-middleware": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-retry": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.4.tgz",
-          "integrity": "sha512-Cyolv9YckZTPli1EkkaS39UklonxMd08VskiuMhURDjC0HHa/AD6aK/YoD21CHv9s0QLg0WMLvk9YeLTKkXaFQ==",
-          "requires": {
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/service-error-classification": "^2.1.3",
-            "@smithy/smithy-client": "^2.4.2",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-retry": "^2.1.3",
-            "tslib": "^2.5.0",
-            "uuid": "^8.3.2"
-          }
-        },
-        "@smithy/middleware-serde": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
-          "integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-stack": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
-          "integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/node-config-provider": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
-          "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
-          "requires": {
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.4",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/node-http-handler": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
-          "integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
-          "requires": {
-            "@smithy/abort-controller": "^2.1.3",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/querystring-builder": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
-          "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/querystring-builder": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
-          "integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-uri-escape": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/querystring-parser": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
-          "integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/service-error-classification": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.3.tgz",
-          "integrity": "sha512-iUrpSsem97bbXHHT/v3s7vaq8IIeMo6P6cXdeYHrx0wOJpMeBGQF7CB0mbJSiTm3//iq3L55JiEm8rA7CTVI8A==",
-          "requires": {
-            "@smithy/types": "^2.10.1"
-          }
-        },
-        "@smithy/shared-ini-file-loader": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
-          "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/signature-v4": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
-          "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
-          "requires": {
-            "@smithy/eventstream-codec": "^2.1.3",
-            "@smithy/is-array-buffer": "^2.1.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-uri-escape": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/smithy-client": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
-          "integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
-          "requires": {
-            "@smithy/middleware-endpoint": "^2.4.4",
-            "@smithy/middleware-stack": "^2.1.3",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-stream": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/url-parser": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
-          "integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
-          "requires": {
-            "@smithy/querystring-parser": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-defaults-mode-browser": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.4.tgz",
-          "integrity": "sha512-J6XAVY+/g7jf03QMnvqPyU+8jqGrrtXoKWFVOS+n1sz0Lg8HjHJ1ANqaDN+KTTKZRZlvG8nU5ZrJOUL6VdwgcQ==",
-          "requires": {
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/smithy-client": "^2.4.2",
-            "@smithy/types": "^2.10.1",
-            "bowser": "^2.11.0",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-defaults-mode-node": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.3.tgz",
-          "integrity": "sha512-ttUISrv1uVOjTlDa3nznX33f0pthoUlP+4grhTvOzcLhzArx8qHB94/untGACOG3nlf8vU20nI2iWImfzoLkYA==",
-          "requires": {
-            "@smithy/config-resolver": "^2.1.4",
-            "@smithy/credential-provider-imds": "^2.2.4",
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/smithy-client": "^2.4.2",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-endpoints": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.4.tgz",
-          "integrity": "sha512-/qAeHmK5l4yQ4/bCIJ9p49wDe9rwWtOzhPHblu386fwPNT3pxmodgcs9jDCV52yK9b4rB8o9Sj31P/7Vzka1cg==",
-          "requires": {
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
-          "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.3.tgz",
-          "integrity": "sha512-Kbvd+GEMuozbNUU3B89mb99tbufwREcyx2BOX0X2+qHjq6Gvsah8xSDDgxISDwcOHoDqUWO425F0Uc/QIRhYkg==",
-          "requires": {
-            "@smithy/service-error-classification": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-stream": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
-          "integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
-          "requires": {
-            "@smithy/fetch-http-handler": "^2.4.3",
-            "@smithy/node-http-handler": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-base64": "^2.1.1",
-            "@smithy/util-buffer-from": "^2.1.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.523.0",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.523.0",
+        "@aws-sdk/region-config-resolver": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.523.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.523.0",
+        "@smithy/config-resolver": "^2.1.3",
+        "@smithy/core": "^1.3.4",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.3",
+        "@smithy/middleware-retry": "^2.1.3",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.3",
+        "@smithy/util-defaults-mode-node": "^2.2.2",
+        "@smithy/util-endpoints": "^1.1.3",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.523.0.tgz",
+      "integrity": "sha512-OktkdiuJ5DtYgNrJlo53Tf7pJ+UWfOt7V7or0ije6MysLP18GwlTkbg2UE4EUtfOxt/baXxHMlExB1vmRtlATw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.523.0",
+        "@aws-sdk/core": "3.523.0",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.523.0",
+        "@aws-sdk/region-config-resolver": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.523.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.523.0",
+        "@smithy/config-resolver": "^2.1.3",
+        "@smithy/core": "^1.3.4",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.3",
+        "@smithy/middleware-retry": "^2.1.3",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.3",
+        "@smithy/util-defaults-mode-node": "^2.2.2",
+        "@smithy/util-endpoints": "^1.1.3",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.523.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.523.0.tgz",
+      "integrity": "sha512-ggAkL8szaJkqD8oOsS68URJ9XMDbLA/INO/NPZJqv9BhmftecJvfy43uUVWGNs6n4YXNzfF0Y+zQ3DT0fZkv9g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.523.0",
+        "@aws-sdk/middleware-host-header": "3.523.0",
+        "@aws-sdk/middleware-logger": "3.523.0",
+        "@aws-sdk/middleware-recursion-detection": "3.523.0",
+        "@aws-sdk/middleware-user-agent": "3.523.0",
+        "@aws-sdk/region-config-resolver": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.523.0",
+        "@aws-sdk/util-user-agent-browser": "3.523.0",
+        "@aws-sdk/util-user-agent-node": "3.523.0",
+        "@smithy/config-resolver": "^2.1.3",
+        "@smithy/core": "^1.3.4",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/hash-node": "^2.1.3",
+        "@smithy/invalid-dependency": "^2.1.3",
+        "@smithy/middleware-content-length": "^2.1.3",
+        "@smithy/middleware-endpoint": "^2.4.3",
+        "@smithy/middleware-retry": "^2.1.3",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-body-length-browser": "^2.1.1",
+        "@smithy/util-body-length-node": "^2.2.1",
+        "@smithy/util-defaults-mode-browser": "^2.1.3",
+        "@smithy/util-defaults-mode-node": "^2.2.2",
+        "@smithy/util-endpoints": "^1.1.3",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "@smithy/util-utf8": "^2.1.1",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.523.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.523.0.tgz",
+      "integrity": "sha512-JHa3ngEWkTzZ2YTn6EavcADC8gv6zZU4U9WBAleClh6ioXH0kGMBawZje3y0F0mKyLTfLhFqFUlCV5sngI/Qcw==",
+      "dependencies": {
+        "@smithy/core": "^1.3.4",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/signature-v4": "^2.1.3",
+        "@smithy/smithy-client": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.523.0.tgz",
+      "integrity": "sha512-Y6DWdH6/OuMDoNKVzZlNeBc6f1Yjk1lYMjANKpIhMbkRCvLJw/PYZKOZa8WpXbTYdgg9XLjKybnLIb3ww3uuzA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.523.0.tgz",
+      "integrity": "sha512-6YUtePbn3UFpY9qfVwHFWIVnFvVS5vsbGxxkTO02swvZBvVG4sdG0Xj0AbotUNQNY9QTCN7WkhwIrd50rfDQ9Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-stream": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.523.0.tgz",
+      "integrity": "sha512-dRch5Ts67FFRZY5r9DpiC3PM6BVHv1tRcy1b26hoqfFkxP9xYH3dsTSPBog1azIqaJa2GcXqEvKCqhghFTt4Xg==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.523.0",
+        "@aws-sdk/credential-provider-env": "3.523.0",
+        "@aws-sdk/credential-provider-process": "3.523.0",
+        "@aws-sdk/credential-provider-sso": "3.523.0",
+        "@aws-sdk/credential-provider-web-identity": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/credential-provider-imds": "^2.2.3",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.523.0.tgz",
+      "integrity": "sha512-0aW5ylA8pZmvv/8qA/+iel4acEyzSlHRiaHYL3L0qu9SSoe2a92+RHjrxKl6+Sb55eA2mRfQjaN8oOa5xiYyKA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.523.0",
+        "@aws-sdk/credential-provider-http": "3.523.0",
+        "@aws-sdk/credential-provider-ini": "3.523.0",
+        "@aws-sdk/credential-provider-process": "3.523.0",
+        "@aws-sdk/credential-provider-sso": "3.523.0",
+        "@aws-sdk/credential-provider-web-identity": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/credential-provider-imds": "^2.2.3",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.523.0.tgz",
+      "integrity": "sha512-f0LP9KlFmMvPWdKeUKYlZ6FkQAECUeZMmISsv6NKtvPCI9e4O4cLTeR09telwDK8P0HrgcRuZfXM7E30m8re0Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.523.0.tgz",
+      "integrity": "sha512-/VfOJuI8ImV//W4gr+yieF/4shzWAzWYeaaNu7hv161C5YW7/OoCygwRVHSnF4KKeUGQZomZWwml5zHZ57f8xQ==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.523.0",
+        "@aws-sdk/token-providers": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.523.0.tgz",
+      "integrity": "sha512-EyBwVoTNZrhLRIHly3JnLzy86deT2hHGoxSCrT3+cVcF1Pq3FPp6n9fUkHd6Yel+wFrjpXCRggLddPvajUoXtQ==",
+      "dependencies": {
+        "@aws-sdk/client-sts": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.523.0.tgz",
+      "integrity": "sha512-4g3q7Ta9sdD9TMUuohBAkbx/e3I/juTqfKi7TPgP+8jxcYX72MOsgemAMHuP6CX27eyj4dpvjH+w4SIVDiDSmg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.523.0.tgz",
+      "integrity": "sha512-PeDNJNhfiaZx54LBaLTXzUaJ9LXFwDFFIksipjqjvxMafnoVcQwKbkoPUWLe5ytT4nnL1LogD3s55mERFUsnwg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.523.0.tgz",
+      "integrity": "sha512-nZ3Vt7ehfSDYnrcg/aAfjjvpdE+61B3Zk68i6/hSUIegT3IH9H1vSW67NDKVp+50hcEfzWwM2HMPXxlzuyFyrw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.523.0.tgz",
+      "integrity": "sha512-5OoKkmAPNaxLgJuS65gByW1QknGvvXdqzrIMXLsm9LjbsphTOscyvT439qk3Jf08TL4Zlw2x+pZMG7dZYuMAhQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@aws-sdk/util-endpoints": "3.523.0",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.523.0.tgz",
+      "integrity": "sha512-IypIAecBc8b4jM0uVBEj90NYaIsc0vuLdSFyH4LPO7is4rQUet4CkkD+S036NvDdcdxBsQ4hJZBmWrqiizMHhQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/node-config-provider": "^2.2.3",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.523.0.tgz",
+      "integrity": "sha512-m3sPEnLuGV3JY9A8ytcz90SogVtjxEyIxUDFeswxY4C5wP/36yOq3ivenRu07dH+QIJnBhsQdjnHwJfrIetG6g==",
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.523.0",
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.523.0.tgz",
+      "integrity": "sha512-f4qe4AdafjAZoVGoVt69Jb2rXCgo306OOobSJ/f4bhQ0zgAjGELKJATNRRe0J7P28+ffmSxeuYwM3r4gDkD/QA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-endpoints": "^1.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.523.0.tgz",
+      "integrity": "sha512-6ZRNdGHX6+HQFqTbIA5+i8RWzxFyxsZv8D3soRfpdyWIKkzhSz8IyRKXRciwKBJDaC7OX2jzGE90wxRQft27nA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/types": "^2.10.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.523.0.tgz",
+      "integrity": "sha512-tW7vliJ77EsE8J1bzFpDYCiUyrw2NTcem+J5ddiWD4HA/xNQUyX0CMOXMBZCBA31xLTIchyz0LkZHlDsmB9LUw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.523.0",
+        "@smithy/node-config-provider": "^2.2.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
         }
       }
     },
-    "@aws-sdk/client-sso": {
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/abort-controller": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
+      "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/config-resolver": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.4.tgz",
+      "integrity": "sha512-AW2WUZmBAzgO3V3ovKtsUbI3aBNMeQKFDumoqkNxaVDWF/xfnxAWqBKDr/NuG7c06N2Rm4xeZLPiJH/d+na0HA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-config-provider": "^2.2.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/core": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.5.tgz",
+      "integrity": "sha512-Rrc+e2Jj6Gu7Xbn0jvrzZlSiP2CZocIOfZ9aNUA82+1sa6GBnxqL9+iZ9EKHeD9aqD1nU8EK4+oN2EiFpSv7Yw==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-retry": "^2.1.4",
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/credential-provider-imds": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.4.tgz",
+      "integrity": "sha512-DdatjmBZQnhGe1FhI8gO98f7NmvQFSDiZTwC3WMvLTCKQUY+Y1SVkhJqIuLu50Eb7pTheoXQmK+hKYUgpUWsNA==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+      "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
+      "integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/querystring-builder": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-base64": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/hash-node": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.3.tgz",
+      "integrity": "sha512-FsAPCUj7VNJIdHbSxMd5uiZiF20G2zdSDgrgrDrHqIs/VMxK85Vqk5kMVNNDMCZmMezp6UKnac0B4nAyx7HJ9g==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/invalid-dependency": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.3.tgz",
+      "integrity": "sha512-wkra7d/G4CbngV4xsjYyAYOvdAhahQje/WymuQdVEnXFExJopEu7fbL5AEAlBPgWHXwu94VnCSG00gVzRfExyg==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-content-length": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.3.tgz",
+      "integrity": "sha512-aJduhkC+dcXxdnv5ZpM3uMmtGmVFKx412R1gbeykS5HXDmRU6oSsyy2SoHENCkfOGKAQOjVE2WVqDJibC0d21g==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-endpoint": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
+      "integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/shared-ini-file-loader": "^2.3.4",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-middleware": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-retry": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.4.tgz",
+      "integrity": "sha512-Cyolv9YckZTPli1EkkaS39UklonxMd08VskiuMhURDjC0HHa/AD6aK/YoD21CHv9s0QLg0WMLvk9YeLTKkXaFQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/service-error-classification": "^2.1.3",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-retry": "^2.1.3",
+        "tslib": "^2.5.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-serde": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
+      "integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/middleware-stack": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
+      "integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-config-provider": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
+      "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.4",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-http-handler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
+      "integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/querystring-builder": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/property-provider": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
+      "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/querystring-builder": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
+      "integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/querystring-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
+      "integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/service-error-classification": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.3.tgz",
+      "integrity": "sha512-iUrpSsem97bbXHHT/v3s7vaq8IIeMo6P6cXdeYHrx0wOJpMeBGQF7CB0mbJSiTm3//iq3L55JiEm8rA7CTVI8A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
+      "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/signature-v4": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
+      "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.1.3",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/smithy-client": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
+      "integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-stream": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/url-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
+      "integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.4.tgz",
+      "integrity": "sha512-J6XAVY+/g7jf03QMnvqPyU+8jqGrrtXoKWFVOS+n1sz0Lg8HjHJ1ANqaDN+KTTKZRZlvG8nU5ZrJOUL6VdwgcQ==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.2.3.tgz",
+      "integrity": "sha512-ttUISrv1uVOjTlDa3nznX33f0pthoUlP+4grhTvOzcLhzArx8qHB94/untGACOG3nlf8vU20nI2iWImfzoLkYA==",
+      "dependencies": {
+        "@smithy/config-resolver": "^2.1.4",
+        "@smithy/credential-provider-imds": "^2.2.4",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/smithy-client": "^2.4.2",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-endpoints": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.4.tgz",
+      "integrity": "sha512-/qAeHmK5l4yQ4/bCIJ9p49wDe9rwWtOzhPHblu386fwPNT3pxmodgcs9jDCV52yK9b4rB8o9Sj31P/7Vzka1cg==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-middleware": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
+      "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-retry": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.3.tgz",
+      "integrity": "sha512-Kbvd+GEMuozbNUU3B89mb99tbufwREcyx2BOX0X2+qHjq6Gvsah8xSDDgxISDwcOHoDqUWO425F0Uc/QIRhYkg==",
+      "dependencies": {
+        "@smithy/service-error-classification": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/util-stream": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
+      "integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.540.0.tgz",
       "integrity": "sha512-rrQZMuw4sxIo3eyAUUzPQRA336mPRnrAeSlSdVHBKZD8Fjvoy0lYry2vNhkPLpFZLso1J66KRyuIv4LzRR3v1Q==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.535.0",
@@ -1105,101 +1343,17 @@
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
-          "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "@smithy/util-utf8": "^2.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-browser": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
-          "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-node": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
-          "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/client-sso-oidc": {
+    "node_modules/@aws-sdk/client-sso-oidc": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.540.0.tgz",
       "integrity": "sha512-LZYK0lBRQK8D8M3Sqc96XiXkAV2v70zhTtF6weyzEpgwxZMfSuFJjs0jFyhaeZBZbZv7BBghIdhJ5TPavNxGMQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/client-sts": "3.540.0",
@@ -1240,101 +1394,232 @@
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
-          "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "@smithy/util-utf8": "^2.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-browser": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
-          "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-node": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
-          "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.540.0"
       }
     },
-    "@aws-sdk/client-sts": {
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-body-length-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-body-length-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.540.0.tgz",
       "integrity": "sha512-ITHUQxvpqfQX6obfpIi3KYGzZYfe/I5Ixjfxoi5lB7ISCtmxqObKB1fzD93wonkMJytJ7LUO8panZl/ojiJ1uw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
         "@aws-sdk/core": "3.535.0",
@@ -1374,101 +1659,126 @@
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
-          "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "@smithy/util-utf8": "^2.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-browser": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
-          "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-node": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
-          "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": "^3.540.0"
       }
     },
-    "@aws-sdk/core": {
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-body-length-node": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.535.0.tgz",
       "integrity": "sha512-+Yusa9HziuaEDta1UaLEtMAtmgvxdxhPn7jgfRY6PplqAqgsfa5FR83sxy5qr2q7xjQTwHtV4MjQVuOjG9JsLw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/core": "^1.4.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/signature-v4": "^2.2.0",
@@ -1477,99 +1787,117 @@
         "fast-xml-parser": "4.2.5",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-cognito-identity": {
+    "node_modules/@aws-sdk/core/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.540.0.tgz",
       "integrity": "sha512-XOTAIuVgticX+43GMpRbi5OHmJAhHfoHYsVGu0eRLhri1yFqUHXJgHUd51QQtlA8cFQN7JnFFM6sF5EDCPF49g==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.540.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-env": {
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
       "integrity": "sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-http": {
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.535.0.tgz",
       "integrity": "sha512-kdj1wCmOMZ29jSlUskRqN04S6fJ4dvt0Nq9Z32SA6wO7UG8ht6Ot9h/au/eTWJM3E1somZ7D771oK7dQt9b8yw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/fetch-http-handler": "^2.5.0",
         "@smithy/node-http-handler": "^2.5.0",
@@ -1580,37 +1908,44 @@
         "@smithy/util-stream": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-ini": {
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.540.0.tgz",
       "integrity": "sha512-igN/RbsnulIBwqXbwsWmR3srqmtbPF1dm+JteGvUY31FW65fTVvWvSr945Y/cf1UbhPmIQXntlsqESqpkhTHwg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/client-sts": "3.540.0",
         "@aws-sdk/credential-provider-env": "3.535.0",
         "@aws-sdk/credential-provider-process": "3.535.0",
@@ -1623,37 +1958,44 @@
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-node": {
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.540.0.tgz",
       "integrity": "sha512-HKQZJbLHlrHX9A0B1poiYNXIIQfy8whTjuosTCYKPDBhhUyVAQfxy/KG726j0v43IhaNPLgTGZCJve4hAsazSw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/credential-provider-env": "3.535.0",
         "@aws-sdk/credential-provider-http": "3.535.0",
         "@aws-sdk/credential-provider-ini": "3.540.0",
@@ -1667,74 +2009,88 @@
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-process": {
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.535.0.tgz",
       "integrity": "sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/shared-ini-file-loader": "^2.4.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-sso": {
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.540.0.tgz",
       "integrity": "sha512-tKkFqK227LF5ajc5EL6asXS32p3nkofpP8G7NRpU7zOEOQCg01KUc4JRX+ItI0T007CiN1J19yNoFqHLT/SqHg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/client-sso": "3.540.0",
         "@aws-sdk/token-providers": "3.540.0",
         "@aws-sdk/types": "3.535.0",
@@ -1743,74 +2099,88 @@
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-provider-web-identity": {
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.540.0.tgz",
       "integrity": "sha512-OpDm9w3A168B44hSjpnvECP4rvnFzD86rN4VYdGADuCvEa5uEcdA/JuT5WclFPDqdWEmFBqS1pxBIJBf0g2Q9Q==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/client-sts": "3.540.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/credential-providers": {
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.540.0.tgz",
       "integrity": "sha512-tAmvqdZngCrER5/AAwTmDSjO05LGIshKL+lwcJr2OUV5jtQVzfbFrorf+b5dnI+3i8+zGcEAV9omra4XGrO9Kg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/client-cognito-identity": "3.540.0",
         "@aws-sdk/client-sso": "3.540.0",
         "@aws-sdk/client-sts": "3.540.0",
@@ -1828,35 +2198,42 @@
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-bucket-endpoint": {
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.523.0.tgz",
       "integrity": "sha512-mrZbixWjk0d9NqxC4xBnKtfwErum0we4Uk2O4fgvDVI+XxAimUlZ9c4o/QJ2+TzeQ/8QclT2k4WidsQdWtPNvg==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.523.0",
         "@aws-sdk/util-arn-parser": "3.495.0",
         "@smithy/node-config-provider": "^2.2.3",
@@ -1865,108 +2242,137 @@
         "@smithy/util-config-provider": "^2.2.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/node-config-provider": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
-          "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
-          "requires": {
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.4",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
-          "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/shared-ini-file-loader": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
-          "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-expect-continue": {
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/node-config-provider": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
+      "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.4",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/property-provider": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
+      "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
+      "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.523.0.tgz",
       "integrity": "sha512-E5DyRAHU39VHaAlQLqXYS/IKpgk3vsryuU6kkOcIIK8Dgw0a2tjoh5AOCaNa8pD+KgAGrFp35JIMSX1zui5diA==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.523.0",
         "@smithy/protocol-http": "^3.2.1",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-flexible-checksums": {
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.523.0.tgz",
       "integrity": "sha512-lIa1TdWY9q4zsDFarfSnYcdrwPR+nypaU4n6hb95i620/1F5M5s6H8P0hYtwTNNvx+slrR8F3VBML9pjBtzAHw==",
-      "requires": {
+      "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@aws-crypto/crc32c": "3.0.0",
         "@aws-sdk/types": "3.523.0",
@@ -1976,176 +2382,214 @@
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-host-header": {
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.535.0.tgz",
       "integrity": "sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-location-constraint": {
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.523.0.tgz",
       "integrity": "sha512-1QAUXX3U0jkARnU0yyjk81EO4Uw5dCeQOtvUY5s3bUOHatR3ThosQeIr6y9BCsbXHzNnDe1ytCjqAPyo8r/bYw==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.523.0",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-logger": {
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.535.0.tgz",
       "integrity": "sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-recursion-detection": {
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.535.0.tgz",
       "integrity": "sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-sdk-s3": {
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.523.0.tgz",
       "integrity": "sha512-cCZ3+XcAJMSC2rsw5F2h+ILVgjijRTxgzD6l7vExhc7UUOOPxXa6R9oGV3+6ANQ/P0w8rvE78j8UAMzlpq+cZA==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.523.0",
         "@aws-sdk/util-arn-parser": "3.495.0",
         "@smithy/node-config-provider": "^2.2.3",
@@ -2156,226 +2600,278 @@
         "@smithy/util-config-provider": "^2.2.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/abort-controller": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
-          "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/eventstream-codec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-          "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
-          "requires": {
-            "@aws-crypto/crc32": "3.0.0",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/fetch-http-handler": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
-          "integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
-          "requires": {
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/querystring-builder": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-base64": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-endpoint": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
-          "integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
-          "requires": {
-            "@smithy/middleware-serde": "^2.1.3",
-            "@smithy/node-config-provider": "^2.2.4",
-            "@smithy/shared-ini-file-loader": "^2.3.4",
-            "@smithy/types": "^2.10.1",
-            "@smithy/url-parser": "^2.1.3",
-            "@smithy/util-middleware": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-serde": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
-          "integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/middleware-stack": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
-          "integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/node-config-provider": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
-          "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
-          "requires": {
-            "@smithy/property-provider": "^2.1.3",
-            "@smithy/shared-ini-file-loader": "^2.3.4",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/node-http-handler": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
-          "integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
-          "requires": {
-            "@smithy/abort-controller": "^2.1.3",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/querystring-builder": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
-          "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/querystring-builder": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
-          "integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-uri-escape": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/querystring-parser": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
-          "integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/shared-ini-file-loader": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
-          "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/signature-v4": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
-          "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
-          "requires": {
-            "@smithy/eventstream-codec": "^2.1.3",
-            "@smithy/is-array-buffer": "^2.1.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-uri-escape": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/smithy-client": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
-          "integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
-          "requires": {
-            "@smithy/middleware-endpoint": "^2.4.4",
-            "@smithy/middleware-stack": "^2.1.3",
-            "@smithy/protocol-http": "^3.2.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-stream": "^2.1.3",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/url-parser": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
-          "integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
-          "requires": {
-            "@smithy/querystring-parser": "^2.1.3",
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
-          "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-stream": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
-          "integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
-          "requires": {
-            "@smithy/fetch-http-handler": "^2.4.3",
-            "@smithy/node-http-handler": "^2.4.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-base64": "^2.1.1",
-            "@smithy/util-buffer-from": "^2.1.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-signing": {
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/abort-controller": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
+      "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+      "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.3.tgz",
+      "integrity": "sha512-Fn/KYJFo6L5I4YPG8WQb2hOmExgRmNpVH5IK2zU3JKrY5FKW7y9ar5e0BexiIC9DhSKqKX+HeWq/Y18fq7Dkpw==",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/querystring-builder": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-base64": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/middleware-endpoint": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.4.tgz",
+      "integrity": "sha512-4yjHyHK2Jul4JUDBo2sTsWY9UshYUnXeb/TAK/MTaPEb8XQvDmpwSFnfIRDU45RY1a6iC9LCnmJNg/yHyfxqkw==",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.1.3",
+        "@smithy/node-config-provider": "^2.2.4",
+        "@smithy/shared-ini-file-loader": "^2.3.4",
+        "@smithy/types": "^2.10.1",
+        "@smithy/url-parser": "^2.1.3",
+        "@smithy/util-middleware": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/middleware-serde": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.3.tgz",
+      "integrity": "sha512-s76LId+TwASrHhUa9QS4k/zeXDUAuNuddKklQzRgumbzge5BftVXHXIqL4wQxKGLocPwfgAOXWx+HdWhQk9hTg==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/middleware-stack": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.3.tgz",
+      "integrity": "sha512-opMFufVQgvBSld/b7mD7OOEBxF6STyraVr1xel1j0abVILM8ALJvRoFbqSWHGmaDlRGIiV9Q5cGbWi0sdiEaLQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/node-config-provider": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.4.tgz",
+      "integrity": "sha512-nqazHCp8r4KHSFhRQ+T0VEkeqvA0U+RhehBSr1gunUuNW3X7j0uDrWBxB2gE9eutzy6kE3Y7L+Dov/UXT871vg==",
+      "dependencies": {
+        "@smithy/property-provider": "^2.1.3",
+        "@smithy/shared-ini-file-loader": "^2.3.4",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/node-http-handler": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.4.1.tgz",
+      "integrity": "sha512-HCkb94soYhJMxPCa61wGKgmeKpJ3Gftx1XD6bcWEB2wMV1L9/SkQu/6/ysKBnbOzWRE01FGzwrTxucHypZ8rdg==",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/querystring-builder": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/property-provider": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
+      "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/querystring-builder": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.3.tgz",
+      "integrity": "sha512-kFD3PnNqKELe6m9GRHQw/ftFFSZpnSeQD4qvgDB6BQN6hREHELSosVFUMPN4M3MDKN2jAwk35vXHLoDrNfKu0A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/querystring-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.3.tgz",
+      "integrity": "sha512-3+CWJoAqcBMR+yvz6D+Fc5VdoGFtfenW6wqSWATWajrRMGVwJGPT3Vy2eb2bnMktJc4HU4bpjeovFa566P3knQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.4.tgz",
+      "integrity": "sha512-CiZmPg9GeDKbKmJGEFvJBsJcFnh0AQRzOtQAzj1XEa8N/0/uSN/v1LYzgO7ry8hhO8+9KB7+DhSW0weqBra4Aw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/signature-v4": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
+      "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.1.3",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/smithy-client": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.4.2.tgz",
+      "integrity": "sha512-ntAFYN51zu3N3mCd95YFcFi/8rmvm//uX+HnK24CRbI6k5Rjackn0JhgKz5zOx/tbNvOpgQIwhSX+1EvEsBLbA==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.4.4",
+        "@smithy/middleware-stack": "^2.1.3",
+        "@smithy/protocol-http": "^3.2.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-stream": "^2.1.3",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/url-parser": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.3.tgz",
+      "integrity": "sha512-X1NRA4WzK/ihgyzTpeGvI9Wn45y8HmqF4AZ/FazwAv8V203Ex+4lXqcYI70naX9ETqbqKVzFk88W6WJJzCggTQ==",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.1.3",
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-middleware": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
+      "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@smithy/util-stream": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.3.tgz",
+      "integrity": "sha512-HvpEQbP8raTy9n86ZfXiAkf3ezp1c3qeeO//zGqwZdrfaoOpGKQgF2Sv1IqZp7wjhna7pvczWaGUHjcOPuQwKw==",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.4.3",
+        "@smithy/node-http-handler": "^2.4.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-base64": "^2.1.1",
+        "@smithy/util-buffer-from": "^2.1.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.523.0.tgz",
       "integrity": "sha512-pFXV4don6qcmew/OvEjLUr2foVjzoJ8o5k57Oz9yAHz8INx3RHK8MP/K4mVhHo6n0SquRcWrm4kY/Tw+89gkEA==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.523.0",
         "@smithy/property-provider": "^2.1.3",
         "@smithy/protocol-http": "^3.2.1",
@@ -2384,152 +2880,185 @@
         "@smithy/util-middleware": "^2.1.3",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/eventstream-codec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-          "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
-          "requires": {
-            "@aws-crypto/crc32": "3.0.0",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
-          "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/signature-v4": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
-          "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
-          "requires": {
-            "@smithy/eventstream-codec": "^2.1.3",
-            "@smithy/is-array-buffer": "^2.1.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-uri-escape": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
-          "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-ssec": {
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+      "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/property-provider": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.3.tgz",
+      "integrity": "sha512-bMz3se+ySKWNrgm7eIiQMa2HO/0fl2D0HvLAdg9pTMcpgp4SqOAh6bz7Ik6y7uQqSrk4rLjIKgbQ6yzYgGehCQ==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/signature-v4": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
+      "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.1.3",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@smithy/util-middleware": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
+      "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.523.0.tgz",
       "integrity": "sha512-FaqAZQeF5cQzZLOIboIJRaWVOQ2F2pJZAXGF5D7nJsxYNFChotA0O0iWimBRxU35RNn7yirVxz35zQzs20ddIw==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.523.0",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/middleware-user-agent": {
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.540.0.tgz",
       "integrity": "sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@aws-sdk/util-endpoints": "3.540.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/region-config-resolver": {
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.535.0.tgz",
       "integrity": "sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/types": "^2.12.0",
@@ -2537,45 +3066,55 @@
         "@smithy/util-middleware": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-config-provider": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
-          "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/signature-v4-multi-region": {
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver/node_modules/@smithy/util-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.523.0.tgz",
       "integrity": "sha512-TU1AfF6YlihdMy4H5YtkmFYmA/Zrh7sqk2V6tPiR2Vu6idc+9xm1R0UE/2V/DKgMIkxfr4+cAojtp2kqYuuF/A==",
-      "requires": {
+      "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "3.523.0",
         "@aws-sdk/types": "3.523.0",
         "@smithy/protocol-http": "^3.2.1",
@@ -2583,77 +3122,93 @@
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.523.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
-          "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/eventstream-codec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-          "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
-          "requires": {
-            "@aws-crypto/crc32": "3.0.0",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
-          "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/signature-v4": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
-          "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
-          "requires": {
-            "@smithy/eventstream-codec": "^2.1.3",
-            "@smithy/is-array-buffer": "^2.1.1",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "@smithy/util-middleware": "^2.1.3",
-            "@smithy/util-uri-escape": "^2.1.1",
-            "@smithy/util-utf8": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
-          "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/token-providers": {
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
+      "version": "3.523.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.523.0.tgz",
+      "integrity": "sha512-AqGIu4u+SxPiUuNBp2acCVcq80KDUFjxe6e3cMTvKWTzCbrVk1AXv0dAaJnCmdkWIha6zJDWxpIk/aL4EGhZ9A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+      "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/protocol-http": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.2.1.tgz",
+      "integrity": "sha512-KLrQkEw4yJCeAmAH7hctE8g9KwA7+H2nSJwxgwIxchbp/L0B5exTdOQi9D5HinPLlothoervGmhpYKelZ6AxIA==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/signature-v4": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.3.tgz",
+      "integrity": "sha512-Jq4iPPdCmJojZTsPePn4r1ULShh6ONkokLuxp1Lnk4Sq7r7rJp4HlA1LbPBq4bD64TIzQezIpr1X+eh5NYkNxw==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.1.3",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.3",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@smithy/util-middleware": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.3.tgz",
+      "integrity": "sha512-/+2fm7AZ2ozl5h8wM++ZP0ovE9/tiUUAHIbCfGfb3Zd3+Dyk17WODPKXBeJ/TnK5U+x743QmA0xHzlSm8I/qhw==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.540.0.tgz",
       "integrity": "sha512-9BvtiVEZe5Ev88Wa4ZIUbtT6BVcPwhxmVInQ6c12MYNb0WNL54BN6wLy/eknAfF05gpX2/NDU2pUDOyMPdm/+g==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/client-sso-oidc": "3.540.0",
         "@aws-sdk/types": "3.535.0",
         "@smithy/property-provider": "^2.2.0",
@@ -2661,307 +3216,393 @@
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/types": {
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
       "version": "3.515.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
       "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.9.1",
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/util-arn-parser": {
+    "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.495.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.495.0.tgz",
       "integrity": "sha512-hwdA3XAippSEUxs7jpznwD63YYFR+LtQvlEcebPTgWR9oQgG9TfS+39PUfbnEeje1ICuOrN3lrFqFbmP9uzbMg==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/util-endpoints": {
+    "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.540.0.tgz",
       "integrity": "sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/types": "^2.12.0",
         "@smithy/util-endpoints": "^1.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/util-locate-window": {
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.495.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.495.0.tgz",
       "integrity": "sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@aws-sdk/util-user-agent-browser": {
+    "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.535.0.tgz",
       "integrity": "sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
-    "@aws-sdk/util-user-agent-node": {
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.535.0.tgz",
       "integrity": "sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-sdk/types": "3.535.0",
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.535.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
-          "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/types": "^2.12.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
         }
       }
     },
-    "@aws-sdk/util-utf8-browser": {
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
+      "version": "3.535.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.535.0.tgz",
+      "integrity": "sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.3.1"
       }
     },
-    "@aws-sdk/xml-builder": {
+    "node_modules/@aws-sdk/xml-builder": {
       "version": "3.523.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.523.0.tgz",
       "integrity": "sha512-wfvyVymj2TUw7SuDor9IuFcAzJZvWRBZotvY/wQJOlYa3UP3Oezzecy64N4FWfBJEsZdrTN+HOZFl+IzTWWnUA==",
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@babel/code-frame": {
+    "node_modules/@aws-sdk/xml-builder/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
       "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
     },
-    "@babel/helper-validator-identifier": {
+    "node_modules/@babel/helper-validator-identifier": {
       "version": "7.15.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
       "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
-    "@babel/highlight": {
+    "node_modules/@babel/highlight": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
       "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@babel/helper-validator-identifier": "^7.15.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "@babel/parser": {
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/parser": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
       "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
-    "@babel/runtime": {
+    "node_modules/@babel/runtime": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
       "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
-      "requires": {
+      "dependencies": {
         "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "@chenfengyuan/vue-countdown": {
+    "node_modules/@chenfengyuan/vue-countdown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@chenfengyuan/vue-countdown/-/vue-countdown-1.1.5.tgz",
-      "integrity": "sha512-BB0taTfJzxsXFUPioREWLKpMDdHOoD8EiSW6lhB3yCdJh3I7jiNQzC8Hw5dPxoPNgZekeEPMQwsdPkjQPyxIeA=="
+      "integrity": "sha512-BB0taTfJzxsXFUPioREWLKpMDdHOoD8EiSW6lhB3yCdJh3I7jiNQzC8Hw5dPxoPNgZekeEPMQwsdPkjQPyxIeA==",
+      "peerDependencies": {
+        "vue": "^2.6.0"
+      }
     },
-    "@discordjs/collection": {
+    "node_modules/@discordjs/collection": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
-      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ=="
+      "integrity": "sha512-utRNxnd9kSS2qhyivo9lMlt5qgAUasH2gb7BEOn6p0efFh24gjGomHzWKMAPn2hEReOPQZCJaRKoURwRotKucQ==",
+      "deprecated": "no longer supported"
     },
-    "@discordjs/form-data": {
+    "node_modules/@discordjs/form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@discordjs/form-data/-/form-data-3.0.1.tgz",
       "integrity": "sha512-ZfFsbgEXW71Rw/6EtBdrP5VxBJy4dthyC0tpQKGKmYFImlmmrykO14Za+BiIVduwjte0jXEBlhSKf0MWbFp9Eg==",
-      "requires": {
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "@emnapi/runtime": {
+    "node_modules/@emnapi/runtime": {
       "version": "0.45.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-0.45.0.tgz",
       "integrity": "sha512-Txumi3td7J4A/xTTwlssKieHKTGl3j4A1tglBx72auZ49YK7ePY6XZricgIg9mnZT4xPfA+UPCUdnhRuEFDL+w==",
       "optional": true,
-      "requires": {
+      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
-    "@eslint-community/eslint-utils": {
+    "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
       "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-          "dev": true
-        }
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
-    "@eslint-community/regexpp": {
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
       "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
     },
-    "@eslint/eslintrc": {
+    "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
       "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
@@ -2972,178 +3613,477 @@
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
-      "dependencies": {
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
-        }
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "@humanwhocodes/config-array": {
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
       "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.0",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
       }
     },
-    "@humanwhocodes/object-schema": {
+    "node_modules/@humanwhocodes/object-schema": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
-    "@img/sharp-darwin-arm64": {
+    "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.2.tgz",
       "integrity": "sha512-itHBs1rPmsmGF9p4qRe++CzCgd+kFYktnsoR1sbIAfsRMrJZau0Tt1AH9KVnufc2/tU02Gf6Ibujx+15qRE03w==",
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-darwin-arm64": "1.0.1"
       }
     },
-    "@img/sharp-darwin-x64": {
+    "node_modules/@img/sharp-darwin-x64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.2.tgz",
       "integrity": "sha512-/rK/69Rrp9x5kaWBjVN07KixZanRr+W1OiyKdXcbjQD6KbW+obaTeBBtLUAtbBsnlTTmWthw99xqoOS7SsySDg==",
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-darwin-x64": "1.0.1"
       }
     },
-    "@img/sharp-libvips-darwin-arm64": {
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.1.tgz",
       "integrity": "sha512-kQyrSNd6lmBV7O0BUiyu/OEw9yeNGFbQhbxswS1i6rMDwBBSX+e+rPzu3S+MwAiGU3HdLze3PanQ4Xkfemgzcw==",
-      "optional": true
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=11",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-darwin-x64": {
+    "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.1.tgz",
       "integrity": "sha512-eVU/JYLPVjhhrd8Tk6gosl5pVlvsqiFlt50wotCvdkFGf+mDNBJxMh+bvav+Wt3EBnNZWq8Sp2I7XfSjm8siog==",
-      "optional": true
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "macos": ">=10.13",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-linux-arm": {
+    "node_modules/@img/sharp-libvips-linux-arm": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.1.tgz",
       "integrity": "sha512-FtdMvR4R99FTsD53IA3LxYGghQ82t3yt0ZQ93WMZ2xV3dqrb0E8zq4VHaTOuLEAuA83oDawHV3fd+BsAPadHIQ==",
-      "optional": true
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-linux-arm64": {
+    "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.1.tgz",
       "integrity": "sha512-bnGG+MJjdX70mAQcSLxgeJco11G+MxTz+ebxlz8Y3dxyeb3Nkl7LgLI0mXupoO+u1wRNx/iRj5yHtzA4sde1yA==",
-      "optional": true
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-linux-s390x": {
+    "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.1.tgz",
       "integrity": "sha512-3+rzfAR1YpMOeA2zZNp+aYEzGNWK4zF3+sdMxuCS3ey9HhDbJ66w6hDSHDMoap32DueFwhhs3vwooAB2MaK4XQ==",
-      "optional": true
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-linux-x64": {
+    "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.1.tgz",
       "integrity": "sha512-3NR1mxFsaSgMMzz1bAnnKbSAI+lHXVTqAHgc1bgzjHuXjo4hlscpUxc0vFSAPKI3yuzdzcZOkq7nDPrP2F8Jgw==",
-      "optional": true
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-linuxmusl-arm64": {
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.1.tgz",
       "integrity": "sha512-5aBRcjHDG/T6jwC3Edl3lP8nl9U2Yo8+oTl5drd1dh9Z1EBfzUKAJFUDTDisDjUwc7N4AjnPGfCA3jl3hY8uDg==",
-      "optional": true
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-libvips-linuxmusl-x64": {
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.1.tgz",
       "integrity": "sha512-dcT7inI9DBFK6ovfeWRe3hG30h51cBAP5JXlZfx6pzc/Mnf9HFCQDLtYf4MCBjxaaTfjCCjkBxcy3XzOAo5txw==",
-      "optional": true
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-linux-arm": {
+    "node_modules/@img/sharp-linux-arm": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.2.tgz",
       "integrity": "sha512-Fndk/4Zq3vAc4G/qyfXASbS3HBZbKrlnKZLEJzPLrXoJuipFNNwTes71+Ki1hwYW5lch26niRYoZFAtZVf3EGA==",
+      "cpu": [
+        "arm"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-linux-arm": "1.0.1"
       }
     },
-    "@img/sharp-linux-arm64": {
+    "node_modules/@img/sharp-linux-arm64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.2.tgz",
       "integrity": "sha512-pz0NNo882vVfqJ0yNInuG9YH71smP4gRSdeL09ukC2YLE6ZyZePAlWKEHgAzJGTiOh8Qkaov6mMIMlEhmLdKew==",
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-linux-arm64": "1.0.1"
       }
     },
-    "@img/sharp-linux-s390x": {
+    "node_modules/@img/sharp-linux-s390x": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.2.tgz",
       "integrity": "sha512-MBoInDXDppMfhSzbMmOQtGfloVAflS2rP1qPcUIiITMi36Mm5YR7r0ASND99razjQUpHTzjrU1flO76hKvP5RA==",
+      "cpu": [
+        "s390x"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.28",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-linux-s390x": "1.0.1"
       }
     },
-    "@img/sharp-linux-x64": {
+    "node_modules/@img/sharp-linux-x64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.2.tgz",
       "integrity": "sha512-xUT82H5IbXewKkeF5aiooajoO1tQV4PnKfS/OZtb5DDdxS/FCI/uXTVZ35GQ97RZXsycojz/AJ0asoz6p2/H/A==",
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "glibc": ">=2.26",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.0.1"
       }
     },
-    "@img/sharp-linuxmusl-arm64": {
+    "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.2.tgz",
       "integrity": "sha512-F+0z8JCu/UnMzg8IYW1TMeiViIWBVg7IWP6nE0p5S5EPQxlLd76c8jYemG21X99UzFwgkRo5yz2DS+zbrnxZeA==",
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.0.1"
       }
     },
-    "@img/sharp-linuxmusl-x64": {
+    "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.2.tgz",
       "integrity": "sha512-+ZLE3SQmSL+Fn1gmSaM8uFusW5Y3J9VOf+wMGNnTtJUMUxFhv+P4UPaYEYT8tqnyYVaOVGgMN/zsOxn9pSsO2A==",
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "requires": {
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "musl": ">=1.2.2",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-x64": "1.0.1"
       }
     },
-    "@img/sharp-wasm32": {
+    "node_modules/@img/sharp-wasm32": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.2.tgz",
       "integrity": "sha512-fLbTaESVKuQcpm8ffgBD7jLb/CQLcATju/jxtTXR1XCLwbOQt+OL5zPHSDMmp2JZIeq82e18yE0Vv7zh6+6BfQ==",
+      "cpu": [
+        "wasm32"
+      ],
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@emnapi/runtime": "^0.45.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
-    "@img/sharp-win32-ia32": {
+    "node_modules/@img/sharp-win32-ia32": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.2.tgz",
       "integrity": "sha512-okBpql96hIGuZ4lN3+nsAjGeggxKm7hIRu9zyec0lnfB8E7Z6p95BuRZzDDXZOl2e8UmR4RhYt631i7mfmKU8g==",
-      "optional": true
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@img/sharp-win32-x64": {
+    "node_modules/@img/sharp-win32-x64": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.2.tgz",
       "integrity": "sha512-E4magOks77DK47FwHUIGH0RYWSgRBfGdK56kIHSVeB9uIS4pPFr4N2kIVsXdQQo4LzOsENKV5KAhRlRL7eMAdg==",
-      "optional": true
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0",
+        "npm": ">=9.6.5",
+        "pnpm": ">=7.1.0",
+        "yarn": ">=3.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
-    "@mapbox/node-pre-gyp": {
+    "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
       "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
-      "requires": {
+      "dependencies": {
         "detect-libc": "^2.0.0",
         "https-proxy-agent": "^5.0.0",
         "make-dir": "^3.1.0",
@@ -3153,127 +4093,150 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
-    "@mongodb-js/saslprep": {
+    "node_modules/@mongodb-js/saslprep": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
       "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
     },
-    "@nodelib/fs.scandir": {
+    "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "@nodelib/fs.stat": {
+    "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
-    "@nodelib/fs.walk": {
+    "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "@smithy/abort-controller": {
+    "node_modules/@smithy/abort-controller": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
       "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/chunked-blob-reader": {
+    "node_modules/@smithy/abort-controller/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.1.tgz",
       "integrity": "sha512-NjNFCKxC4jVvn+lUr3Yo4/PmUJj3tbyqH6GNHueyTGS5Q27vlEJ1MkNhUDV8QGxJI7Bodnc2pD18lU2zRfhHlQ==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
       }
     },
-    "@smithy/chunked-blob-reader-native": {
+    "node_modules/@smithy/chunked-blob-reader-native": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.1.tgz",
       "integrity": "sha512-zNW+43dltfNMUrBEYLMWgI8lQr0uhtTcUyxkgC9EP4j17WREzgSFMPUFVrVV6Rc2+QtWERYjb4tzZnQGa7R9fQ==",
-      "requires": {
+      "dependencies": {
         "@smithy/util-base64": "^2.1.1",
         "tslib": "^2.5.0"
       }
     },
-    "@smithy/config-resolver": {
+    "node_modules/@smithy/config-resolver": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
       "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/types": "^2.12.0",
         "@smithy/util-config-provider": "^2.3.0",
         "@smithy/util-middleware": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-config-provider": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
-          "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/core": {
+    "node_modules/@smithy/config-resolver/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver/node_modules/@smithy/util-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.0.tgz",
       "integrity": "sha512-uu9ZDI95Uij4qk+L6kyFjdk11zqBkcJ3Lv0sc6jZrqHvLyr0+oeekD3CnqMafBn/5PRI6uv6ulW3kNLRBUHeVw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/middleware-endpoint": "^2.5.0",
         "@smithy/middleware-retry": "^2.2.0",
         "@smithy/middleware-serde": "^2.3.0",
@@ -3283,420 +4246,488 @@
         "@smithy/util-middleware": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/credential-provider-imds": {
+    "node_modules/@smithy/core/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
       "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/property-provider": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "@smithy/url-parser": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/eventstream-codec": {
+    "node_modules/@smithy/credential-provider-imds/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
       "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
         "@smithy/types": "^2.12.0",
         "@smithy/util-hex-encoding": "^2.2.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-hex-encoding": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
-          "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
-    "@smithy/eventstream-serde-browser": {
+    "node_modules/@smithy/eventstream-codec/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec/node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.3.tgz",
       "integrity": "sha512-qAgKbZ9m2oBfSyJWWurX/MvQFRPrYypj79cDSleEgDwBoez6Tfd+FTpu2L/j3ZeC3mDlDHIKWksoeaXZpLLAHw==",
-      "requires": {
+      "dependencies": {
         "@smithy/eventstream-serde-universal": "^2.1.3",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/eventstream-serde-config-resolver": {
+    "node_modules/@smithy/eventstream-serde-browser/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.3.tgz",
       "integrity": "sha512-48rvsNv/MgAFCxOE0qwR7ZwKhaEdDoTxqH5HM+T6SDxICmPGb7gEuQzjTxQhcieCPgqyXeZFW8cU0QJxdowuIg==",
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/eventstream-serde-node": {
+    "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.3.tgz",
       "integrity": "sha512-RPJWWDhj8isk3NtGfm3Xt1WdHyX9ZE42V+m1nLU1I0zZ1hEol/oawHsTnhva/VR5bn+bJ2zscx+BYr0cEPRtmg==",
-      "requires": {
+      "dependencies": {
         "@smithy/eventstream-serde-universal": "^2.1.3",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/eventstream-serde-universal": {
+    "node_modules/@smithy/eventstream-serde-node/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.3.tgz",
       "integrity": "sha512-ssvSMk1LX2jRhiOVgVLGfNJXdB8SvyjieKcJDHq698Gi3LOog6g/+l7ggrN+hZxyjUiDF4cUxgKaZTBUghzhLw==",
-      "requires": {
+      "dependencies": {
         "@smithy/eventstream-codec": "^2.1.3",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/eventstream-codec": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
-          "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
-          "requires": {
-            "@aws-crypto/crc32": "3.0.0",
-            "@smithy/types": "^2.10.1",
-            "@smithy/util-hex-encoding": "^2.1.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/fetch-http-handler": {
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.3.tgz",
+      "integrity": "sha512-rGlCVuwSDv6qfKH4/lRxFjcZQnIE0LZ3D4lkMHg7ZSltK9rA74r0VuGSvWVQ4N/d70VZPaniFhp4Z14QYZsa+A==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.10.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
       "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/querystring-builder": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "@smithy/util-base64": "^2.3.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
-          "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "@smithy/util-utf8": "^2.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
-    "@smithy/hash-blob-browser": {
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.3.tgz",
       "integrity": "sha512-sHLTM5xQYw5Wxz07DFo+eh1PVC6P5+kazQRF1k5nsvOhZG5VnkIy4LZ7N0ZNWqJx16g9otGd5MvqUOpb3WWtgA==",
-      "requires": {
+      "dependencies": {
         "@smithy/chunked-blob-reader": "^2.1.1",
         "@smithy/chunked-blob-reader-native": "^2.1.1",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
       }
     },
-    "@smithy/hash-node": {
+    "node_modules/@smithy/hash-blob-browser/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
       "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "@smithy/util-buffer-from": "^2.2.0",
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/hash-stream-node": {
+    "node_modules/@smithy/hash-node/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.1.3.tgz",
       "integrity": "sha512-fWpUx2ca/u5lcD5RhNJogEG5FD7H0RDDpYmfQgxFqIUv3Ow7bZsapMukh8uzQPVO8R+NDAvSdxmgXoy4Hz8sFw==",
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.10.1",
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/invalid-dependency": {
+    "node_modules/@smithy/hash-stream-node/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
       "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
-    "@smithy/is-array-buffer": {
+    "node_modules/@smithy/invalid-dependency/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
       "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/md5-js": {
+    "node_modules/@smithy/md5-js": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.3.tgz",
       "integrity": "sha512-zmn3M6+mP4IJlSmXBN9964AztgkIO8b5lRzAgdJn9AdCFwA6xLkcW2B6uEnpBjvotxtQMmXTUP19tIO7NmFPpw==",
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.10.1",
         "@smithy/util-utf8": "^2.1.1",
         "tslib": "^2.5.0"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
       }
     },
-    "@smithy/middleware-content-length": {
+    "node_modules/@smithy/md5-js/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
       "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/middleware-endpoint": {
+    "node_modules/@smithy/middleware-content-length/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.0.tgz",
       "integrity": "sha512-OBhI9ZEAG8Xen0xsFJwwNOt44WE2CWkfYIxTognC8x42Lfsdf0VN/wCMqpdkySMDio/vts10BiovAxQp0T0faA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/middleware-serde": "^2.3.0",
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/shared-ini-file-loader": "^2.4.0",
@@ -3705,26 +4736,30 @@
         "@smithy/util-middleware": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/middleware-retry": {
+    "node_modules/@smithy/middleware-endpoint/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.2.0.tgz",
       "integrity": "sha512-PsjDOLpbevgn37yJbawmfVoanru40qVA8UEf2+YA1lvOefmhuhL6ZbKtGsLAWDRnE1OlAmedsbA/htH6iSZjNA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/service-error-classification": "^2.1.5",
@@ -3735,278 +4770,328 @@
         "tslib": "^2.6.2",
         "uuid": "^8.3.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true,
-          "optional": true
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/middleware-serde": {
+    "node_modules/@smithy/middleware-retry/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
       "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/middleware-stack": {
+    "node_modules/@smithy/middleware-serde/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
       "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/node-config-provider": {
+    "node_modules/@smithy/middleware-stack/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
       "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/property-provider": "^2.2.0",
         "@smithy/shared-ini-file-loader": "^2.4.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/node-http-handler": {
+    "node_modules/@smithy/node-config-provider/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
       "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/abort-controller": "^2.2.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/querystring-builder": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/property-provider": {
+    "node_modules/@smithy/node-http-handler/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
       "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/protocol-http": {
+    "node_modules/@smithy/property-provider/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
       "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/querystring-builder": {
+    "node_modules/@smithy/protocol-http/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
       "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "@smithy/util-uri-escape": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-uri-escape": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
-          "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/querystring-parser": {
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
       "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/service-error-classification": {
+    "node_modules/@smithy/querystring-parser/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
       "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/shared-ini-file-loader": {
+    "node_modules/@smithy/service-error-classification/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
       "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/signature-v4": {
+    "node_modules/@smithy/shared-ini-file-loader/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.2.0.tgz",
       "integrity": "sha512-+B5TNzj/fRZzVW3z8UUJOkNx15+4E0CLuvJmJUA1JUIZFp3rdJ/M2H5r2SqltaVPXL0oIxv/6YK92T9TsFGbFg==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/eventstream-codec": "^2.2.0",
         "@smithy/is-array-buffer": "^2.2.0",
         "@smithy/types": "^2.12.0",
@@ -4016,78 +5101,97 @@
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-hex-encoding": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
-          "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-uri-escape": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
-          "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/smithy-client": {
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.0.tgz",
       "integrity": "sha512-DDXWHWdimtS3y/Kw1Jo46KQ0ZYsDKcldFynQERUGBPDpkW1lXOTHy491ALHjwfiBQvzsVKVxl5+ocXNIgJuX4g==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/middleware-endpoint": "^2.5.0",
         "@smithy/middleware-stack": "^2.2.0",
         "@smithy/protocol-http": "^3.3.0",
@@ -4095,126 +5199,150 @@
         "@smithy/util-stream": "^2.2.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/types": {
+    "node_modules/@smithy/smithy-client/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
       "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/url-parser": {
+    "node_modules/@smithy/url-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
       "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/querystring-parser": "^2.2.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
       }
     },
-    "@smithy/util-base64": {
+    "node_modules/@smithy/url-parser/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
       "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
-      "requires": {
+      "dependencies": {
         "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-body-length-browser": {
+    "node_modules/@smithy/util-body-length-browser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
       "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
       }
     },
-    "@smithy/util-body-length-node": {
+    "node_modules/@smithy/util-body-length-node": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
       "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-buffer-from": {
+    "node_modules/@smithy/util-buffer-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
       "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
-      "requires": {
+      "dependencies": {
         "@smithy/is-array-buffer": "^2.1.1",
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-config-provider": {
+    "node_modules/@smithy/util-config-provider": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
       "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-defaults-mode-browser": {
+    "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.0.tgz",
       "integrity": "sha512-2okTdZaCBvOJszAPU/KSvlimMe35zLOKbQpHhamFJmR7t95HSe0K3C92jQPjKY3PmDBD+7iMkOnuW05F5OlF4g==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/property-provider": "^2.2.0",
         "@smithy/smithy-client": "^2.5.0",
         "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "@smithy/util-defaults-mode-node": {
+    "node_modules/@smithy/util-defaults-mode-browser/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.0.tgz",
       "integrity": "sha512-hfKXnNLmsW9cmLb/JXKIvtuO6Cf4SuqN5PN1C2Ru/TBIws+m1wSgb+A53vo0r66xzB6E82inKG2J7qtwdi+Kkw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/config-resolver": "^2.2.0",
         "@smithy/credential-provider-imds": "^2.3.0",
         "@smithy/node-config-provider": "^2.3.0",
@@ -4223,105 +5351,124 @@
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "@smithy/util-endpoints": {
+    "node_modules/@smithy/util-defaults-mode-node/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
       "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "@smithy/util-hex-encoding": {
+    "node_modules/@smithy/util-endpoints/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
       "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-middleware": {
+    "node_modules/@smithy/util-middleware": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
       "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-retry": {
+    "node_modules/@smithy/util-middleware/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
       "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/service-error-classification": "^2.1.5",
         "@smithy/types": "^2.12.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
-    "@smithy/util-stream": {
+    "node_modules/@smithy/util-retry/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
       "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "@smithy/fetch-http-handler": "^2.5.0",
         "@smithy/node-http-handler": "^2.5.0",
         "@smithy/types": "^2.12.0",
@@ -4331,166 +5478,201 @@
         "@smithy/util-utf8": "^2.3.0",
         "tslib": "^2.6.2"
       },
-      "dependencies": {
-        "@smithy/is-array-buffer": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
-          "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
-          "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "@smithy/util-utf8": "^2.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-hex-encoding": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
-          "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^2.2.0",
-            "tslib": "^2.6.2"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-uri-escape": {
+    "node_modules/@smithy/util-stream/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
       "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
-      "requires": {
+      "dependencies": {
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-utf8": {
+    "node_modules/@smithy/util-utf8": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
       "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
-      "requires": {
+      "dependencies": {
         "@smithy/util-buffer-from": "^2.1.1",
         "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@smithy/util-waiter": {
+    "node_modules/@smithy/util-waiter": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.3.tgz",
       "integrity": "sha512-3R0wNFAQQoH9e4m+bVLDYNOst2qNxtxFgq03WoNHWTBOqQT3jFnOBRj1W51Rf563xDA5kwqjziksxn6RKkHB+Q==",
-      "requires": {
+      "dependencies": {
         "@smithy/abort-controller": "^2.1.3",
         "@smithy/types": "^2.10.1",
         "tslib": "^2.5.0"
       },
-      "dependencies": {
-        "@smithy/abort-controller": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
-          "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
-          "requires": {
-            "@smithy/types": "^2.10.1",
-            "tslib": "^2.5.0"
-          }
-        },
-        "@smithy/types": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
-          "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
-          "requires": {
-            "tslib": "^2.5.0"
-          }
-        }
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "@tozd/vue-observer-utils": {
+    "node_modules/@smithy/util-waiter/node_modules/@smithy/abort-controller": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.3.tgz",
+      "integrity": "sha512-c2aYH2Wu1RVE3rLlVgg2kQOBJGM0WbjReQi5DnPTm2Zb7F0gk7J2aeQeaX2u/lQZoHl6gv8Oac7mt9alU3+f4A==",
+      "dependencies": {
+        "@smithy/types": "^2.10.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter/node_modules/@smithy/types": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.10.1.tgz",
+      "integrity": "sha512-hjQO+4ru4cQ58FluQvKKiyMsFg0A6iRpGm2kqdH8fniyNd2WyanoOsYJfMX/IFLuLxEoW6gnRkNZy1y6fUUhtA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tozd/vue-observer-utils": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@tozd/vue-observer-utils/-/vue-observer-utils-0.5.0.tgz",
-      "integrity": "sha512-HeRxWFJB7FXcQigH2LvauiR0l7hA4qqBC6hK9rBeKf076Ew08C4lx3eo7/YmvADt3b8ZP1j+TN0pGCEhKYOhEA=="
+      "integrity": "sha512-HeRxWFJB7FXcQigH2LvauiR0l7hA4qqBC6hK9rBeKf076Ew08C4lx3eo7/YmvADt3b8ZP1j+TN0pGCEhKYOhEA==",
+      "peerDependencies": {
+        "vue": ">=2.6.0"
+      }
     },
-    "@types/chai": {
+    "node_modules/@types/chai": {
       "version": "4.3.11",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.11.tgz",
       "integrity": "sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==",
       "dev": true
     },
-    "@types/connect": {
+    "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/jquery": {
+    "node_modules/@types/jquery": {
       "version": "3.5.29",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
       "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/sizzle": "*"
       }
     },
-    "@types/json-schema": {
+    "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "@types/lodash": {
+    "node_modules/@types/lodash": {
       "version": "4.14.202",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
       "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
-    "@types/meteor": {
+    "node_modules/@types/meteor": {
       "version": "2.9.8",
       "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-2.9.8.tgz",
       "integrity": "sha512-p96s1lMqtwt0hz50yokQJA+V9BQzNMLJfahwlbbfXKwbI/OMNCKhRfnxiiNROXAF080zctJlEcpjmv0YG7ztkA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/connect": "*",
         "@types/jquery": "*",
         "@types/node": "*",
@@ -4500,112 +5682,112 @@
         "mongodb": "^4.3.1"
       }
     },
-    "@types/meteor-mdg-validated-method": {
+    "node_modules/@types/meteor-mdg-validated-method": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/meteor-mdg-validated-method/-/meteor-mdg-validated-method-1.2.10.tgz",
       "integrity": "sha512-3xWIlRZuTaxe1Ogo/kA+eaJ9Dnlptk4wOb1e92ZjQ4mB3lRXW5JcFU7o/y6yd0L62xTtukjZOatXy/xpoDEdGQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/meteor": "*",
         "@types/node": "*"
       }
     },
-    "@types/mocha": {
+    "node_modules/@types/mocha": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "20.11.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
       "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
-    "@types/nodemailer": {
+    "node_modules/@types/nodemailer": {
       "version": "6.4.14",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.14.tgz",
       "integrity": "sha512-fUWthHO9k9DSdPCSPRqcu6TWhYyxTBg382vlNIttSe9M7XfsT06y0f24KHXtbnijPGGRIcVvdKHTNikOI6qiHA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/prop-types": {
+    "node_modules/@types/prop-types": {
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
       "dev": true
     },
-    "@types/react": {
+    "node_modules/@types/react": {
       "version": "18.2.71",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.71.tgz",
       "integrity": "sha512-PxEsB9OjmQeYGffoWnYAd/r5FiJuUw2niFQHPc2v2idwh8wGPkkYzOHuinNJJY6NZqfoTCiOIizDOz38gYNsyw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
-    "@types/scheduler": {
+    "node_modules/@types/scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
       "dev": true
     },
-    "@types/semver": {
+    "node_modules/@types/semver": {
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
       "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
       "dev": true
     },
-    "@types/simpl-schema": {
+    "node_modules/@types/simpl-schema": {
       "version": "1.12.7",
       "resolved": "https://registry.npmjs.org/@types/simpl-schema/-/simpl-schema-1.12.7.tgz",
       "integrity": "sha512-GhXOCJqKcDeawYoIe4Jly7C5ePR3Uh3jaswb1U+Ruh1x7EtZqOJMMyxnoVvJUIl5b+v7yoFs4RVny/ZowyXBDw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/meteor": "*"
       }
     },
-    "@types/sizzle": {
+    "node_modules/@types/sizzle": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
       "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
-    "@types/underscore": {
+    "node_modules/@types/underscore": {
       "version": "1.11.15",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.15.tgz",
       "integrity": "sha512-HP38xE+GuWGlbSRq9WrZkousaQ7dragtZCruBVMi0oX1migFZavZ3OROKHSkNp/9ouq82zrWtZpg18jFnVN96g==",
       "dev": true
     },
-    "@types/webidl-conversions": {
+    "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
       "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
       "dev": true
     },
-    "@types/whatwg-url": {
+    "node_modules/@types/whatwg-url": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
       "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
-    "@typescript-eslint/eslint-plugin": {
+    "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/type-utils": "5.62.0",
@@ -4617,86 +5799,164 @@
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
         }
       }
     },
-    "@typescript-eslint/parser": {
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/typescript-estree": "5.62.0",
         "debug": "^4.3.4"
       },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
+    "node_modules/@typescript-eslint/parser/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
       "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "@typescript-eslint/type-utils": {
+    "node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
       "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@typescript-eslint/typescript-estree": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
         }
       }
     },
-    "@typescript-eslint/types": {
+    "node_modules/@typescript-eslint/type-utils/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
       "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
-    "@typescript-eslint/typescript-estree": {
+    "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
       "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
         "debug": "^4.3.4",
@@ -4705,24 +5965,42 @@
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
         }
       }
     },
-    "@typescript-eslint/utils": {
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
       "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
@@ -4731,32 +6009,53 @@
         "@typescript-eslint/typescript-estree": "5.62.0",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "@typescript-eslint/visitor-keys": {
+    "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
       "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
       },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-          "dev": true
-        }
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "@vue/compiler-core": {
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.19.tgz",
       "integrity": "sha512-gj81785z0JNzRcU0Mq98E56e4ltO1yf8k5PQ+tV/7YHnbZkrM0fyFyuttnN8ngJZjbpofWE/m4qjKBiLl8Ju4w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@babel/parser": "^7.23.9",
         "@vue/shared": "3.4.19",
         "entities": "^4.5.0",
@@ -4764,311 +6063,395 @@
         "source-map-js": "^1.0.2"
       }
     },
-    "@vue/compiler-dom": {
+    "node_modules/@vue/compiler-dom": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.19.tgz",
       "integrity": "sha512-vm6+cogWrshjqEHTzIDCp72DKtea8Ry/QVpQRYoyTIg9k7QZDX6D8+HGURjtmatfgM8xgCFtJJaOlCaRYRK3QA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@vue/compiler-core": "3.4.19",
         "@vue/shared": "3.4.19"
       }
     },
-    "@vue/reactivity": {
+    "node_modules/@vue/reactivity": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.19.tgz",
       "integrity": "sha512-+VcwrQvLZgEclGZRHx4O2XhyEEcKaBi50WbxdVItEezUf4fqRh838Ix6amWTdX0CNb/b6t3Gkz3eOebfcSt+UA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@vue/shared": "3.4.19"
       }
     },
-    "@vue/runtime-core": {
+    "node_modules/@vue/runtime-core": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.19.tgz",
       "integrity": "sha512-/Z3tFwOrerJB/oyutmJGoYbuoadphDcJAd5jOuJE86THNZji9pYjZroQ2NFsZkTxOq0GJbb+s2kxTYToDiyZzw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@vue/reactivity": "3.4.19",
         "@vue/shared": "3.4.19"
       }
     },
-    "@vue/runtime-dom": {
+    "node_modules/@vue/runtime-dom": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.19.tgz",
       "integrity": "sha512-IyZzIDqfNCF0OyZOauL+F4yzjMPN2rPd8nhqPP2N1lBn3kYqJpPHHru+83Rkvo2lHz5mW+rEeIMEF9qY3PB94g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@vue/runtime-core": "3.4.19",
         "@vue/shared": "3.4.19",
         "csstype": "^3.1.3"
       }
     },
-    "@vue/shared": {
+    "node_modules/@vue/shared": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.19.tgz",
       "integrity": "sha512-/KliRRHMF6LoiThEy+4c1Z4KB/gbPrGjWwJR+crg2otgrf/egKzRaCPvJ51S5oetgsgXLfc4Rm5ZgrKHZrtMSw==",
       "dev": true
     },
-    "abbrev": {
+    "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
-    "abort-controller": {
+    "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
+      "dependencies": {
         "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
-    "acorn": {
+    "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "acorn-jsx": {
+    "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
     },
-    "add-event-listener": {
+    "node_modules/add-event-listener": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/add-event-listener/-/add-event-listener-0.0.1.tgz",
       "integrity": "sha512-hjRmkeDqFUWEFcDHP/Lp0Pa4MhIJk/oQX8B7lFiNrjBKHjf0q+ivCJrucY8d8UI5d0QkZgV2jGdAGXxEZcm3nA=="
     },
-    "agent-base": {
+    "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "requires": {
+      "dependencies": {
         "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
-    "ajv": {
+    "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "alea": {
+    "node_modules/alea": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/alea/-/alea-1.0.1.tgz",
       "integrity": "sha512-QU+wv+ziDXaMxRdsQg/aH7sVfWdhKps5YP97IIwFkHCsbDZA3k87JXoZ5/iuemf4ntytzIWeScrRpae8+lDrXA=="
     },
-    "ansi-colors": {
+    "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "ansi-regex": {
+    "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "aproba": {
+    "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
     },
-    "are-we-there-yet": {
+    "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
       "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-      "requires": {
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "argparse": {
+    "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-union": {
+    "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "asn1": {
+    "node_modules/asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
+      "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
-    "assert-plus": {
+    "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
-    "assertion-error": {
+    "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "astral-regex": {
+    "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "asynckit": {
+    "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "aws-sign2": {
+    "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "engines": {
+        "node": "*"
+      }
     },
-    "aws4": {
+    "node_modules/aws4": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
-    "babel-runtime": {
+    "node_modules/babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
+      "dependencies": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
       }
     },
-    "balanced-match": {
+    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "base64-js": {
+    "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "bcrypt": {
+    "node_modules/bcrypt": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
       "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
-      "requires": {
+      "hasInstallScript": true,
+      "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "node-addon-api": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
-    "bcrypt-pbkdf": {
+    "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      },
       "dependencies": {
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        }
+        "tweetnacl": "^0.14.3"
       }
     },
-    "bowser": {
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
-    "brace-expansion": {
+    "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "requires": {
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
+    "node_modules/braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "bson": {
+    "node_modules/bson": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
       "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "buffer": {
+    "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
-      "requires": {
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
-    "buffer-from": {
+    "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
-    "callsites": {
+    "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "caseless": {
+    "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "chai": {
+    "node_modules/chai": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
       "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
         "deep-eql": "^4.1.3",
@@ -5076,302 +6459,381 @@
         "loupe": "^2.3.6",
         "pathval": "^1.1.1",
         "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "chalk": {
+    "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "check-error": {
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/chalk/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "chownr": {
+    "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "chroma-js": {
+    "node_modules/chroma-js": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.4.2.tgz",
       "integrity": "sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A=="
     },
-    "clone": {
+    "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
-    "color": {
+    "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "requires": {
+      "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
       },
-      "dependencies": {
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
+      "engines": {
+        "node": ">=12.5.0"
       }
     },
-    "color-convert": {
+    "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "color-name": "1.1.3"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "color-string": {
+    "node_modules/color-string": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "requires": {
+      "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
     },
-    "color-support": {
+    "node_modules/color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "bin": {
+        "color-support": "bin.js"
+      }
     },
-    "combined-stream": {
+    "node_modules/color/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
+      "dependencies": {
         "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "commander": {
+    "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "console-control-strings": {
+    "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
-    "core-js": {
+    "node_modules/core-js": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true
     },
-    "core-util-is": {
+    "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "cross-spawn": {
+    "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "css-box-shadow": {
+    "node_modules/css-box-shadow": {
       "version": "1.0.0-3",
       "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
       "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg=="
     },
-    "csstype": {
+    "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
-    "cytoscape": {
+    "node_modules/cytoscape": {
       "version": "3.28.1",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.28.1.tgz",
       "integrity": "sha512-xyItz4O/4zp9/239wCcH8ZcFuuZooEeF8KHRmzjDfGdXsj3OG9MFSMA0pJE0uX3uCN/ygof6hHf4L7lst+JaDg==",
-      "requires": {
+      "dependencies": {
         "heap": "^0.2.6",
         "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "cytoscape-dagre": {
+    "node_modules/cytoscape-dagre": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
       "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
-      "requires": {
+      "dependencies": {
         "dagre": "^0.8.5"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.22"
       }
     },
-    "cytoscape-klay": {
+    "node_modules/cytoscape-klay": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/cytoscape-klay/-/cytoscape-klay-3.1.4.tgz",
       "integrity": "sha512-VwPj0VR25GPfy6qXVQRi/MYlZM/zkdvRhHlgqbM//lSvstgM6fhp3ik/uM8Wr8nlhskfqz/M1fIDmR6UckbS2A==",
-      "requires": {
+      "dependencies": {
         "klayjs": "^0.4.1"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
       }
     },
-    "dagre": {
+    "node_modules/dagre": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
       "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "requires": {
+      "dependencies": {
         "graphlib": "^2.1.8",
         "lodash": "^4.17.15"
       }
     },
-    "dashdash": {
+    "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "date-fns": {
+    "node_modules/date-fns": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
-    "ddp-rate-limiter-mixin": {
+    "node_modules/ddp-rate-limiter-mixin": {
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/ddp-rate-limiter-mixin/-/ddp-rate-limiter-mixin-1.1.10.tgz",
       "integrity": "sha1-WIx5zw8RUrUKtbGHBkLKAcZy5uY=",
-      "requires": {
+      "dependencies": {
         "babel-runtime": "6.x.x"
       }
     },
-    "debug": {
+    "node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "requires": {
+      "dependencies": {
         "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "deep-eql": {
+    "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
       "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "deep-is": {
+    "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "delayed-stream": {
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "delegates": {
+    "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
-    "detect-libc": {
+    "node_modules/detect-libc": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
-      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw=="
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "dir-glob": {
+    "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "discontinuous-range": {
+    "node_modules/discontinuous-range": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
     },
-    "discord.js": {
+    "node_modules/discord.js": {
       "version": "12.5.3",
       "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.5.3.tgz",
       "integrity": "sha512-D3nkOa/pCkNyn6jLZnAiJApw2N9XrIsXUAdThf01i7yrEuqUmDGc7/CexVWwEcgbQR97XQ+mcnqJpmJ/92B4Aw==",
-      "requires": {
+      "deprecated": "no longer supported",
+      "dependencies": {
         "@discordjs/collection": "^0.1.6",
         "@discordjs/form-data": "^3.0.1",
         "abort-controller": "^3.0.0",
@@ -5380,63 +6842,85 @@
         "setimmediate": "^1.0.5",
         "tweetnacl": "^1.0.3",
         "ws": "^7.4.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
-    "doctrine": {
+    "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
-    "dompurify": {
+    "node_modules/dompurify": {
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.7.tgz",
       "integrity": "sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ=="
     },
-    "ecc-jsbn": {
+    "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
+      "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
-    "emoji-regex": {
+    "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
-    "enquirer": {
+    "node_modules/enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-colors": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
-    "entities": {
+    "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
-    "escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "eslint": {
+    "node_modules/eslint": {
       "version": "7.32.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
         "@humanwhocodes/config-array": "^0.5.0",
@@ -5478,320 +6962,427 @@
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-          "dev": true
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
-    "eslint-plugin-vue": {
+    "node_modules/eslint-plugin-vue": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.20.0.tgz",
       "integrity": "sha512-oVNDqzBC9h3GO+NTgWeLMhhGigy6/bQaQbHS+0z7C4YEu/qK/yxHvca/2PTZtGNPsCrHwOTgKMrwu02A9iPBmw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "eslint-utils": "^2.1.0",
         "natural-compare": "^1.4.0",
         "semver": "^6.3.0",
         "vue-eslint-parser": "^7.10.0"
       },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=8.10"
+      },
+      "peerDependencies": {
+        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "eslint-plugin-vuetify": {
+    "node_modules/eslint-plugin-vue/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-vuetify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-vuetify/-/eslint-plugin-vuetify-1.1.0.tgz",
       "integrity": "sha512-I1YRUCGkDqe8F7O0tdf63UZVKtk4734+8fzbZ24YIZKTTyQp/FIR0nSZYG8mPFhTWerzPta7oXNzliBOwP2XeQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "eslint-plugin-vue": "^7.0.0",
         "requireindex": "^1.2.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0",
+        "vuetify": "^2.0.0"
       }
     },
-    "eslint-scope": {
+    "node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
-    "eslint-utils": {
+    "node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "eslint-visitor-keys": {
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "espree": {
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
       "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "acorn": "^7.4.0",
         "acorn-jsx": "^5.3.1",
         "eslint-visitor-keys": "^1.3.0"
       },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "esprima": {
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "esquery": {
+    "node_modules/esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "estraverse": "^5.1.0"
       },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=0.10"
       }
     },
-    "esrecurse": {
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "estraverse": "^5.2.0"
       },
-      "dependencies": {
-        "estraverse": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=4.0"
       }
     },
-    "estraverse": {
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
-    "estree-walker": {
+    "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "esutils": {
+    "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "event-target-shim": {
+    "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "extend": {
+    "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
-    "extsprintf": {
+    "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "engines": [
+        "node >=0.6.0"
+      ]
     },
-    "fast-deep-equal": {
+    "node_modules/fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
-    "fast-glob": {
+    "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
       }
     },
-    "fast-json-stable-stringify": {
+    "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
-    "fast-levenshtein": {
+    "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "fast-xml-parser": {
+    "node_modules/fast-xml-parser": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
-      "requires": {
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
         "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
-    "fastq": {
+    "node_modules/fastq": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
       "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "reusify": "^1.0.4"
       }
     },
-    "file-entry-cache": {
+    "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "fill-range": {
+    "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "flat-cache": {
+    "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
       "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "flatted": {
+    "node_modules/flatted": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
     },
-    "forever-agent": {
+    "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "engines": {
+        "node": "*"
+      }
     },
-    "form-data": {
+    "node_modules/form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
+      "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
-    "fs-minipass": {
+    "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "requires": {
+      "dependencies": {
         "minipass": "^3.0.0"
       },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "functional-red-black-tree": {
+    "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
     },
-    "gauge": {
+    "node_modules/gauge": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
       "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
-      "requires": {
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
@@ -5801,448 +7392,594 @@
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "get-func-name": {
+    "node_modules/get-func-name": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "getpass": {
+    "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
-    "gintersect": {
+    "node_modules/gintersect": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/gintersect/-/gintersect-0.1.0.tgz",
       "integrity": "sha512-jps8Ckj6u8yLxOYzBVJbPqvRdeHOINQgRtufaLHkunwNQcSEdZU0ejPBapSimXJEQ9mdQW4hsEUN7DfJEcTvQQ=="
     },
-    "glob": {
+    "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "requires": {
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "glob-parent": {
+    "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "globals": {
+    "node_modules/globals": {
       "version": "13.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
       "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "type-fest": "^0.20.2"
       },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "globby": {
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
         "fast-glob": "^3.2.9",
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "graphemer": {
+    "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "graphlib": {
+    "node_modules/graphlib": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
       "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "requires": {
+      "dependencies": {
         "lodash": "^4.17.15"
       }
     },
-    "har-schema": {
+    "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "har-validator": {
+    "node_modules/har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "requires": {
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        }
+      "engines": {
+        "node": ">=6"
       }
     },
-    "has-flag": {
+    "node_modules/har-validator/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "has-unicode": {
+    "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
-    "heap": {
+    "node_modules/heap": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
       "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg=="
     },
-    "http-signature": {
+    "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
+      "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
       }
     },
-    "https-proxy-agent": {
+    "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "requires": {
+      "dependencies": {
         "agent-base": "6",
         "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "ieee754": {
+    "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "ignore": {
+    "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "engines": {
+        "node": ">= 4"
+      }
     },
-    "ignore-styles": {
+    "node_modules/ignore-styles": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ignore-styles/-/ignore-styles-5.0.1.tgz",
       "integrity": "sha1-tJ7yJ0va/NikiAqWa/440aC/RnE="
     },
-    "import-fresh": {
+    "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "imurmurhash": {
+    "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ip-address": {
+    "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
       },
-      "dependencies": {
-        "jsbn": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-          "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-          "dev": true
-        },
-        "sprintf-js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 12"
       }
     },
-    "is-arrayish": {
+    "node_modules/ip-address/node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
+    },
+    "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
-    "is-extglob": {
+    "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "is-fullwidth-code-point": {
+    "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "is-glob": {
+    "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "is-number": {
+    "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
-    "is-typedarray": {
+    "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
-    "isexe": {
+    "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "isstream": {
+    "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
-    "js-tokens": {
+    "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
-    "js-yaml": {
+    "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "jsbn": {
+    "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
-    "json-schema": {
+    "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
-    "json-schema-traverse": {
+    "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
-    "json-stable-stringify-without-jsonify": {
+    "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
-    "json-stringify-safe": {
+    "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
-    "jsprim": {
+    "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "requires": {
+      "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
         "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
-    "klayjs": {
+    "node_modules/klayjs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/klayjs/-/klayjs-0.4.1.tgz",
       "integrity": "sha512-WUNxuO7O79TEkxCj6OIaK5TJBkaWaR/IKNTakgV9PwDn+mrr63MLHed34AcE2yTaDntgO6l0zGFIzhcoTeroTA=="
     },
-    "levn": {
+    "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash._reinterpolate": {
+    "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA=="
     },
-    "lodash.merge": {
+    "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "lodash.omit": {
+    "node_modules/lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
+      "deprecated": "This package is deprecated. Use destructuring assignment syntax instead."
     },
-    "lodash.template": {
+    "node_modules/lodash.template": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
-      "requires": {
+      "deprecated": "This package is deprecated. Use https://socket.dev/npm/package/eta instead.",
+      "dependencies": {
         "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
       }
     },
-    "lodash.templatesettings": {
+    "node_modules/lodash.templatesettings": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
-      "requires": {
+      "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
       }
     },
-    "lodash.truncate": {
+    "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
-    "loupe": {
+    "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "get-func-name": "^2.0.1"
       }
     },
-    "lru-cache": {
+    "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
+      "dependencies": {
         "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "make-dir": {
+    "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "requires": {
+      "dependencies": {
         "semver": "^6.0.0"
       },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
-        }
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "marked": {
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/marked": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
-    "memory-pager": {
+    "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "dev": true,
       "optional": true
     },
-    "merge2": {
+    "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
-    "message-box": {
+    "node_modules/message-box": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.7.tgz",
       "integrity": "sha512-C4ccA5nHb58kTS+pLrgF/JWtr7fAIkHxRDceH7tdy5fMA783nUfbYwZ7H2XLvSeYfcnWIYCig5dWW+icK9X/Ag==",
-      "requires": {
+      "dependencies": {
         "lodash.template": "^4.5.0"
       }
     },
-    "meteor-node-stubs": {
+    "node_modules/meteor-node-stubs": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-1.2.7.tgz",
       "integrity": "sha512-20bAFUhEIOD/Cos2nmvhqf2NOKpTf63WVQ+nwuaX2OFj31sU6GL4KkNylkWum8McwsH0LsMr/F+UHhduTX7KRg==",
-      "requires": {
+      "bundleDependencies": [
+        "assert",
+        "browserify-zlib",
+        "buffer",
+        "console-browserify",
+        "constants-browserify",
+        "crypto-browserify",
+        "domain-browser",
+        "events",
+        "https-browserify",
+        "os-browserify",
+        "path-browserify",
+        "process",
+        "punycode",
+        "querystring-es3",
+        "readable-stream",
+        "stream-browserify",
+        "stream-http",
+        "string_decoder",
+        "timers-browserify",
+        "tty-browserify",
+        "url",
+        "util",
+        "vm-browserify"
+      ],
+      "dependencies": {
         "assert": "^2.0.0",
         "browserify-zlib": "^0.2.0",
         "buffer": "^5.7.1",
@@ -6267,1246 +8004,1736 @@
         "url": "^0.11.0",
         "util": "^0.12.4",
         "vm-browserify": "^1.1.2"
-      },
-      "dependencies": {
-        "asn1.js": {
-          "version": "5.4.1",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "safer-buffer": "^2.1.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "bundled": true
-            }
-          }
-        },
-        "assert": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "available-typed-arrays": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "base64-js": {
-          "version": "1.5.1",
-          "bundled": true
-        },
-        "bn.js": {
-          "version": "5.2.0",
-          "bundled": true
-        },
-        "brorand": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "browserify-aes": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "buffer-xor": "^1.0.3",
-            "cipher-base": "^1.0.0",
-            "create-hash": "^1.1.0",
-            "evp_bytestokey": "^1.0.3",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "browserify-cipher": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "browserify-aes": "^1.0.4",
-            "browserify-des": "^1.0.0",
-            "evp_bytestokey": "^1.0.0"
-          }
-        },
-        "browserify-des": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "cipher-base": "^1.0.1",
-            "des.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "browserify-rsa": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^5.0.0",
-            "randombytes": "^2.0.1"
-          }
-        },
-        "browserify-sign": {
-          "version": "4.2.1",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^5.1.1",
-            "browserify-rsa": "^4.0.1",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "elliptic": "^6.5.3",
-            "inherits": "^2.0.4",
-            "parse-asn1": "^5.1.5",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
-          }
-        },
-        "browserify-zlib": {
-          "version": "0.2.0",
-          "bundled": true,
-          "requires": {
-            "pako": "~1.0.5"
-          }
-        },
-        "buffer": {
-          "version": "5.7.1",
-          "bundled": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "buffer-xor": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "builtin-status-codes": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "call-bind": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2"
-          }
-        },
-        "cipher-base": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "console-browserify": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "constants-browserify": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "create-ecdh": {
-          "version": "4.0.4",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "elliptic": "^6.5.3"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "bundled": true
-            }
-          }
-        },
-        "create-hash": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "cipher-base": "^1.0.1",
-            "inherits": "^2.0.1",
-            "md5.js": "^1.3.4",
-            "ripemd160": "^2.0.1",
-            "sha.js": "^2.4.0"
-          }
-        },
-        "create-hmac": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "cipher-base": "^1.0.3",
-            "create-hash": "^1.1.0",
-            "inherits": "^2.0.1",
-            "ripemd160": "^2.0.0",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
-          }
-        },
-        "crypto-browserify": {
-          "version": "3.12.0",
-          "bundled": true,
-          "requires": {
-            "browserify-cipher": "^1.0.0",
-            "browserify-sign": "^4.0.0",
-            "create-ecdh": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.0",
-            "diffie-hellman": "^5.0.0",
-            "inherits": "^2.0.1",
-            "pbkdf2": "^3.0.3",
-            "public-encrypt": "^4.0.0",
-            "randombytes": "^2.0.0",
-            "randomfill": "^1.0.3"
-          }
-        },
-        "define-properties": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "object-keys": "^1.0.12"
-          }
-        },
-        "des.js": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "diffie-hellman": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "miller-rabin": "^4.0.0",
-            "randombytes": "^2.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "bundled": true
-            }
-          }
-        },
-        "domain-browser": {
-          "version": "4.22.0",
-          "bundled": true
-        },
-        "elliptic": {
-          "version": "6.5.4",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "bundled": true
-            }
-          }
-        },
-        "es-abstract": {
-          "version": "1.18.3",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.2",
-            "is-callable": "^1.2.3",
-            "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
-            "object-inspect": "^1.10.3",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.4",
-            "string.prototype.trimstart": "^1.0.4",
-            "unbox-primitive": "^1.0.1"
-          }
-        },
-        "es-to-primitive": {
-          "version": "1.2.1",
-          "bundled": true,
-          "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
-          }
-        },
-        "es6-object-assign": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "events": {
-          "version": "3.3.0",
-          "bundled": true
-        },
-        "evp_bytestokey": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "md5.js": "^1.3.4",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "foreach": {
-          "version": "2.0.5",
-          "bundled": true
-        },
-        "function-bind": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "get-intrinsic": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "has": {
-          "version": "1.0.3",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1"
-          }
-        },
-        "has-bigints": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "has-symbols": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "hash-base": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.1"
-          }
-        },
-        "hmac-drbg": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "hash.js": "^1.0.3",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.1"
-          }
-        },
-        "https-browserify": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ieee754": {
-          "version": "1.2.1",
-          "bundled": true
-        },
-        "inherits": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "is-arguments": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.0"
-          }
-        },
-        "is-bigint": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "is-boolean-object": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.2"
-          }
-        },
-        "is-callable": {
-          "version": "1.2.3",
-          "bundled": true
-        },
-        "is-date-object": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "is-generator-function": {
-          "version": "1.0.9",
-          "bundled": true
-        },
-        "is-nan": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "is-negative-zero": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "is-number-object": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "is-regex": {
-          "version": "1.1.3",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
-          }
-        },
-        "is-string": {
-          "version": "1.0.6",
-          "bundled": true
-        },
-        "is-symbol": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "has-symbols": "^1.0.2"
-          }
-        },
-        "is-typed-array": {
-          "version": "1.1.5",
-          "bundled": true,
-          "requires": {
-            "available-typed-arrays": "^1.0.2",
-            "call-bind": "^1.0.2",
-            "es-abstract": "^1.18.0-next.2",
-            "foreach": "^2.0.5",
-            "has-symbols": "^1.0.1"
-          }
-        },
-        "md5.js": {
-          "version": "1.3.5",
-          "bundled": true,
-          "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          }
-        },
-        "miller-rabin": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.0.0",
-            "brorand": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "bundled": true
-            }
-          }
-        },
-        "minimalistic-assert": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "minimalistic-crypto-utils": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-inspect": {
-          "version": "1.10.3",
-          "bundled": true
-        },
-        "object-is": {
-          "version": "1.1.5",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "object-keys": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "object.assign": {
-          "version": "4.1.2",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        },
-        "os-browserify": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "pako": {
-          "version": "1.0.11",
-          "bundled": true
-        },
-        "parse-asn1": {
-          "version": "5.1.6",
-          "bundled": true,
-          "requires": {
-            "asn1.js": "^5.2.0",
-            "browserify-aes": "^1.0.0",
-            "evp_bytestokey": "^1.0.0",
-            "pbkdf2": "^3.0.3",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "path-browserify": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "pbkdf2": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "create-hash": "^1.1.2",
-            "create-hmac": "^1.1.4",
-            "ripemd160": "^2.0.1",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
-          }
-        },
-        "process": {
-          "version": "0.11.10",
-          "bundled": true
-        },
-        "public-encrypt": {
-          "version": "4.0.3",
-          "bundled": true,
-          "requires": {
-            "bn.js": "^4.1.0",
-            "browserify-rsa": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "parse-asn1": "^5.0.0",
-            "randombytes": "^2.0.1",
-            "safe-buffer": "^5.1.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.0",
-              "bundled": true
-            }
-          }
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "querystring": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "querystring-es3": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "randombytes": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "randomfill": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "randombytes": "^2.0.5",
-            "safe-buffer": "^5.1.0"
-          }
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "ripemd160": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "setimmediate": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "sha.js": {
-          "version": "2.4.11",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "stream-browserify": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "inherits": "~2.0.4",
-            "readable-stream": "^3.5.0"
-          }
-        },
-        "stream-http": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "builtin-status-codes": "^3.0.0",
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.6.0",
-            "xtend": "^4.0.2"
-          }
-        },
-        "string.prototype.trimend": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "string.prototype.trimstart": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "call-bind": "^1.0.2",
-            "define-properties": "^1.1.3"
-          }
-        },
-        "string_decoder": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "~5.2.0"
-          }
-        },
-        "timers-browserify": {
-          "version": "2.0.12",
-          "bundled": true,
-          "requires": {
-            "setimmediate": "^1.0.4"
-          }
-        },
-        "tty-browserify": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "unbox-primitive": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "function-bind": "^1.1.1",
-            "has-bigints": "^1.0.1",
-            "has-symbols": "^1.0.2",
-            "which-boxed-primitive": "^1.0.2"
-          }
-        },
-        "url": {
-          "version": "0.11.0",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.3.2",
-            "querystring": "0.2.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.3.2",
-              "bundled": true
-            }
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "bundled": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "vm-browserify": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "which-boxed-primitive": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "is-bigint": "^1.0.1",
-            "is-boolean-object": "^1.1.0",
-            "is-number-object": "^1.0.4",
-            "is-string": "^1.0.5",
-            "is-symbol": "^1.0.3"
-          }
-        },
-        "which-typed-array": {
-          "version": "1.1.4",
-          "bundled": true,
-          "requires": {
-            "available-typed-arrays": "^1.0.2",
-            "call-bind": "^1.0.0",
-            "es-abstract": "^1.18.0-next.1",
-            "foreach": "^2.0.5",
-            "function-bind": "^1.1.1",
-            "has-symbols": "^1.0.1",
-            "is-typed-array": "^1.1.3"
-          }
-        },
-        "xtend": {
-          "version": "4.0.2",
-          "bundled": true
-        }
       }
     },
-    "micromatch": {
+    "node_modules/meteor-node-stubs/node_modules/asn1.js": {
+      "version": "5.4.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/assert": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/available-typed-arrays": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/base64-js": {
+      "version": "1.5.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/bn.js": {
+      "version": "5.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/brorand": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/browserify-aes": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/browserify-cipher": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/browserify-des": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/browserify-rsa": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^5.0.0",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/browserify-sign": {
+      "version": "4.2.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/buffer": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/buffer-xor": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/builtin-status-codes": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/call-bind": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/cipher-base": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/console-browserify": {
+      "version": "1.2.0",
+      "inBundle": true
+    },
+    "node_modules/meteor-node-stubs/node_modules/constants-browserify": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/create-ecdh": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/create-ecdh/node_modules/bn.js": {
+      "version": "4.12.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/create-hash": {
+      "version": "1.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/create-hmac": {
+      "version": "1.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/crypto-browserify": {
+      "version": "3.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/define-properties": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/des.js": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/diffie-hellman": {
+      "version": "5.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/diffie-hellman/node_modules/bn.js": {
+      "version": "4.12.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/domain-browser": {
+      "version": "4.22.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/elliptic": {
+      "version": "6.5.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/es-abstract": {
+      "version": "1.18.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/es6-object-assign": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/events": {
+      "version": "3.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/evp_bytestokey": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/foreach": {
+      "version": "2.0.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/function-bind": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/has": {
+      "version": "1.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/has-bigints": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/has-symbols": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/hash-base": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/hash.js": {
+      "version": "1.1.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/https-browserify": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/ieee754": {
+      "version": "1.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/meteor-node-stubs/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-arguments": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-bigint": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-boolean-object": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-callable": {
+      "version": "1.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-date-object": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-generator-function": {
+      "version": "1.0.9",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-nan": {
+      "version": "1.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-number-object": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-regex": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-string": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-symbol": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/is-typed-array": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/md5.js": {
+      "version": "1.3.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/miller-rabin": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/miller-rabin/node_modules/bn.js": {
+      "version": "4.12.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/meteor-node-stubs/node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/object-inspect": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/object-is": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/object-keys": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/object.assign": {
+      "version": "4.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/os-browserify": {
+      "version": "0.3.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/pako": {
+      "version": "1.0.11",
+      "inBundle": true,
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/meteor-node-stubs/node_modules/parse-asn1": {
+      "version": "5.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/path-browserify": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/pbkdf2": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/process": {
+      "version": "0.11.10",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/public-encrypt": {
+      "version": "4.0.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/public-encrypt/node_modules/bn.js": {
+      "version": "4.12.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/punycode": {
+      "version": "1.4.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/querystring": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/querystring-es3": {
+      "version": "0.2.1",
+      "inBundle": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/randombytes": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/randomfill": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/ripemd160": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/setimmediate": {
+      "version": "1.0.5",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/sha.js": {
+      "version": "2.4.11",
+      "inBundle": true,
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/stream-http": {
+      "version": "3.2.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/timers-browserify": {
+      "version": "2.0.12",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/tty-browserify": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/url": {
+      "version": "0.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/util": {
+      "version": "0.12.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/meteor-node-stubs/node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/which-typed-array": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.2",
+        "call-bind": "^1.0.0",
+        "es-abstract": "^1.18.0-next.1",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/meteor-node-stubs/node_modules/xtend": {
+      "version": "4.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
-    "mime-db": {
+    "node_modules/mime-db": {
       "version": "1.46.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
-      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.29",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
       "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
-      "requires": {
+      "dependencies": {
         "mime-db": "1.46.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minify-css-string": {
+    "node_modules/minify-css-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minify-css-string/-/minify-css-string-1.0.0.tgz",
       "integrity": "sha1-IBvZSSceGfbgrwodwMzFg95HxjA="
     },
-    "minimatch": {
+    "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "requires": {
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "minipass": {
+    "node_modules/minipass": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "minizlib": {
+    "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "requires": {
+      "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
       },
-      "dependencies": {
-        "minipass": {
-          "version": "3.3.6",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-          "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        }
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "mkdirp": {
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "mongo-object": {
+    "node_modules/mongo-object": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.4.tgz",
       "integrity": "sha512-QtYk0gupWEn2+iB+DDRt1L+WbcNYvJRaHdih/dcqthOa1DbnREUGSs2WGcW478GNYpElflo/yybZXu0sTiRXHg=="
     },
-    "mongodb": {
+    "node_modules/mongodb": {
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
       "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
       "dev": true,
-      "requires": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "@mongodb-js/saslprep": "^1.1.0",
+      "dependencies": {
         "bson": "^4.7.2",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "@mongodb-js/saslprep": "^1.1.0"
       }
     },
-    "mongodb-connection-string-url": {
+    "node_modules/mongodb-connection-string-url": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
       "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.1"
-          }
-        },
-        "webidl-conversions": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "dev": true,
-          "requires": {
-            "tr46": "^3.0.0",
-            "webidl-conversions": "^7.0.0"
-          }
-        }
       }
     },
-    "moo": {
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="
     },
-    "ms": {
+    "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "natural-compare": {
+    "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "natural-compare-lite": {
+    "node_modules/natural-compare-lite": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
-    "nearley": {
+    "node_modules/nearley": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
       "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "requires": {
+      "dependencies": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
         "railroad-diagrams": "^1.0.0",
         "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
       }
     },
-    "ngraph.centrality": {
+    "node_modules/ngraph.centrality": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ngraph.centrality/-/ngraph.centrality-0.3.0.tgz",
       "integrity": "sha512-Qmu9dDHJAx+GAW2AMqmhaub1rINS+fHZGZJ3zPI36ENAXmVNQ/Jkq79br1sg6NUHz/pRBT9MXMuwDyYKmMt8Mw=="
     },
-    "ngraph.events": {
+    "node_modules/ngraph.events": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.2.1.tgz",
       "integrity": "sha512-D4C+nXH/RFxioGXQdHu8ELDtC6EaCiNsZtih0IvyGN81OZSUby4jXoJ5+RNWasfsd0FnKxxpAROyUMzw64QNsw=="
     },
-    "ngraph.expose": {
+    "node_modules/ngraph.expose": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/ngraph.expose/-/ngraph.expose-0.0.0.tgz",
       "integrity": "sha512-Hr88MuhgoSLVGf2aaaXcKl22Rn95duWsjRcoeJMP9PtFmYHGFw/3ctDqBf5phnIyktm0P/Quxs5EGg6xgJcZAQ=="
     },
-    "ngraph.forcelayout": {
+    "node_modules/ngraph.forcelayout": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ngraph.forcelayout/-/ngraph.forcelayout-0.5.0.tgz",
       "integrity": "sha512-qOd1S9unFLw313+l0M/Dk1MePLDUSl4h9RyOtAbo0CyeefnN4PICiRz0LOewR5WuFmQD0/RmZLpjTKu0H7LTKQ==",
-      "requires": {
+      "dependencies": {
         "ngraph.events": "0.0.4",
         "ngraph.physics.simulator": "^0.3.0"
-      },
-      "dependencies": {
-        "ngraph.events": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.4.tgz",
-          "integrity": "sha512-SY7MdNQoy5KyaVxg03PYCnGF6J7l4p8lEdmYm/5oIqFAmLhg0BmzZzlRqobJ0nEPT6xZlonUQbvCcXtarPZNrg=="
-        }
       }
     },
-    "ngraph.fromjson": {
+    "node_modules/ngraph.forcelayout/node_modules/ngraph.events": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.4.tgz",
+      "integrity": "sha512-SY7MdNQoy5KyaVxg03PYCnGF6J7l4p8lEdmYm/5oIqFAmLhg0BmzZzlRqobJ0nEPT6xZlonUQbvCcXtarPZNrg=="
+    },
+    "node_modules/ngraph.fromjson": {
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/ngraph.fromjson/-/ngraph.fromjson-0.1.9.tgz",
       "integrity": "sha512-f3GLjbUq239wx4s5A0fDptj9dcNeaEIJU3gm74hWvYK7onD7sFtedP7jVHZA7UJ2FwkKgEhzbPeltv92ycuKZQ==",
-      "requires": {
-        "ngraph.graph": "0.0.14"
-      },
       "dependencies": {
-        "ngraph.events": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
-          "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
-        },
-        "ngraph.graph": {
-          "version": "0.0.14",
-          "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-0.0.14.tgz",
-          "integrity": "sha512-ERTLng4KrsGbR7iLZFvg5H+zJ7V+SY8RDqZKYCnOZib5W8M5LCvcil9/8eiJcTRUIPPXW3j8hqPCdLnBvgsn/A==",
-          "requires": {
-            "ngraph.events": "0.0.3"
-          }
-        }
+        "ngraph.graph": "0.0.14"
       }
     },
-    "ngraph.generators": {
+    "node_modules/ngraph.fromjson/node_modules/ngraph.events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
+      "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
+    },
+    "node_modules/ngraph.fromjson/node_modules/ngraph.graph": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-0.0.14.tgz",
+      "integrity": "sha512-ERTLng4KrsGbR7iLZFvg5H+zJ7V+SY8RDqZKYCnOZib5W8M5LCvcil9/8eiJcTRUIPPXW3j8hqPCdLnBvgsn/A==",
+      "dependencies": {
+        "ngraph.events": "0.0.3"
+      }
+    },
+    "node_modules/ngraph.generators": {
       "version": "0.0.19",
       "resolved": "https://registry.npmjs.org/ngraph.generators/-/ngraph.generators-0.0.19.tgz",
       "integrity": "sha512-P3XqB1sH4zrzM6bMGTtuT/6K76Rnhf1qE8Zu7PkAvhQVCQzdLYiL2/8DwhcPLsetRJHNJv0uwpW9TpntBAqKrw==",
-      "requires": {
+      "dependencies": {
         "ngraph.graph": "0.0.14",
         "ngraph.random": "0.1.0"
-      },
-      "dependencies": {
-        "ngraph.events": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
-          "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
-        },
-        "ngraph.graph": {
-          "version": "0.0.14",
-          "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-0.0.14.tgz",
-          "integrity": "sha512-ERTLng4KrsGbR7iLZFvg5H+zJ7V+SY8RDqZKYCnOZib5W8M5LCvcil9/8eiJcTRUIPPXW3j8hqPCdLnBvgsn/A==",
-          "requires": {
-            "ngraph.events": "0.0.3"
-          }
-        },
-        "ngraph.random": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/ngraph.random/-/ngraph.random-0.1.0.tgz",
-          "integrity": "sha512-KXCfzk/ZB79BxQSWMvYPGayx3Mb+7n5GPnc8SW0rwysqRV/3QxEKrLU/UVC8eGjc2SYGofqX+uhUE6IXfqR5VA=="
-        }
       }
     },
-    "ngraph.graph": {
+    "node_modules/ngraph.generators/node_modules/ngraph.events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
+      "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
+    },
+    "node_modules/ngraph.generators/node_modules/ngraph.graph": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-0.0.14.tgz",
+      "integrity": "sha512-ERTLng4KrsGbR7iLZFvg5H+zJ7V+SY8RDqZKYCnOZib5W8M5LCvcil9/8eiJcTRUIPPXW3j8hqPCdLnBvgsn/A==",
+      "dependencies": {
+        "ngraph.events": "0.0.3"
+      }
+    },
+    "node_modules/ngraph.generators/node_modules/ngraph.random": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ngraph.random/-/ngraph.random-0.1.0.tgz",
+      "integrity": "sha512-KXCfzk/ZB79BxQSWMvYPGayx3Mb+7n5GPnc8SW0rwysqRV/3QxEKrLU/UVC8eGjc2SYGofqX+uhUE6IXfqR5VA=="
+    },
+    "node_modules/ngraph.graph": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-19.1.0.tgz",
       "integrity": "sha512-9cws84qfPkrYa7BaBtT+KgZfLXrd6pNL9Gl5Do+MBO/0Hm6rOM7qK78MZaO1uEoIK6p2pgUs6lu29zn/6tP59w==",
-      "requires": {
+      "dependencies": {
         "ngraph.events": "^1.2.1"
       }
     },
-    "ngraph.merge": {
+    "node_modules/ngraph.merge": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/ngraph.merge/-/ngraph.merge-0.0.1.tgz",
       "integrity": "sha512-iXchI5xMjYzA96mee//O7I7gtd4cCakWaSTu11aMTxRDbvBK2qpDDytYg58jO3usAUkjFxBdy1gxYppKmBDuRQ=="
     },
-    "ngraph.path": {
+    "node_modules/ngraph.path": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/ngraph.path/-/ngraph.path-1.5.0.tgz",
       "integrity": "sha512-2IdmqfBYq2zbGHtpmskdWF6x/nIWZkhfs1taMgg2waBJRn4xNqe7gBiRtD1YS5ZcKhp0trK+Gw94Rli2emMs1Q=="
     },
-    "ngraph.physics.primitives": {
+    "node_modules/ngraph.physics.primitives": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ngraph.physics.primitives/-/ngraph.physics.primitives-0.0.7.tgz",
       "integrity": "sha512-7jPm14fYcuJ9kytOVNOKxFy6r/Uu9Dnj++uT3iR9XkBcsBahn2xcYJkV6vF1bIb1fQ5XrDCRjRIOcMwEum6jwQ=="
     },
-    "ngraph.physics.simulator": {
+    "node_modules/ngraph.physics.simulator": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/ngraph.physics.simulator/-/ngraph.physics.simulator-0.3.0.tgz",
       "integrity": "sha512-ObW+HL+hQBIIdc6xG/+qrLe8qv+Sf0X3lq/l2hsjFrIwWtpRKLrSvUUoXiNIeFqRmY/C+PkGo3U+XY523lJ+Fw==",
-      "requires": {
+      "dependencies": {
         "ngraph.events": "0.0.3",
         "ngraph.expose": "0.0.0",
         "ngraph.merge": "0.0.1",
         "ngraph.physics.primitives": "0.0.7",
         "ngraph.quadtreebh": "0.0.4",
         "ngraph.random": "0.0.1"
-      },
-      "dependencies": {
-        "ngraph.events": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
-          "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
-        }
       }
     },
-    "ngraph.quadtreebh": {
+    "node_modules/ngraph.physics.simulator/node_modules/ngraph.events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
+      "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
+    },
+    "node_modules/ngraph.quadtreebh": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/ngraph.quadtreebh/-/ngraph.quadtreebh-0.0.4.tgz",
       "integrity": "sha512-xTIkWGXt5Ajnoq9VOr0xDOI9ZL+q4sPhD0Z7vxvn4MCa+l0wf43rg0C7qv0t+RIOgbQBAp0xDpn568hpXAckJA==",
-      "requires": {
+      "dependencies": {
         "ngraph.random": "0.0.1"
       }
     },
-    "ngraph.random": {
+    "node_modules/ngraph.random": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/ngraph.random/-/ngraph.random-0.0.1.tgz",
       "integrity": "sha512-QPKU7ChXF/VrvMQxVo9aWcvXCXp98VfL4nKUteTW/olDqeUqQ61t7m+jvFb8Dj7kKvlKlnsbDA1aWLJGmm17XA=="
     },
-    "ngraph.tojson": {
+    "node_modules/ngraph.tojson": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/ngraph.tojson/-/ngraph.tojson-0.1.4.tgz",
       "integrity": "sha512-Ii2BTqi8zBRMLH8vTc8pMUKQFJaqbgttG9DKUaazoPVpwC/ww4jyTOHe2ZKaGGZRepnGLqSZ27wZUm7n8MjIgA=="
     },
-    "node-addon-api": {
+    "node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
-    "node-fetch": {
+    "node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
+      "dependencies": {
         "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
-    "nopt": {
+    "node_modules/nopt": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "requires": {
+      "dependencies": {
         "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "npmlog": {
+    "node_modules/npmlog": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
       "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
-      "requires": {
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
         "gauge": "^3.0.0",
         "set-blocking": "^2.0.0"
       }
     },
-    "oauth-sign": {
+    "node_modules/oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
     },
-    "object-assign": {
+    "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "optionator": {
+    "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "parent-module": {
+    "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "path-is-absolute": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-key": {
+    "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "path-type": {
+    "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "pathval": {
+    "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
-    "performance-now": {
+    "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
-    "picomatch": {
+    "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
-    "prelude-ls": {
+    "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
-    "pretty-bytes": {
+    "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="
+      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "prism-media": {
+    "node_modules/prism-media": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.1.tgz",
-      "integrity": "sha512-nyYAa3KB4qteJIqdguKmwxTJgy55xxUtkJ3uRnOvO5jO+frci+9zpRXw6QZVcfDeva3S654fU9+26P2OSTzjHw=="
+      "integrity": "sha512-nyYAa3KB4qteJIqdguKmwxTJgy55xxUtkJ3uRnOvO5jO+frci+9zpRXw6QZVcfDeva3S654fU9+26P2OSTzjHw==",
+      "peerDependencies": {
+        "@discordjs/opus": "^0.5.0",
+        "ffmpeg-static": "^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
     },
-    "progress": {
+    "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
-    "psl": {
+    "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
-    "punycode": {
+    "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
     },
-    "qrcode.vue": {
+    "node_modules/qrcode.vue": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
-      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g=="
+      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
     },
-    "qs": {
+    "node_modules/qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
-    "queue-microtask": {
+    "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "railroad-diagrams": {
+    "node_modules/railroad-diagrams": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
     },
-    "randexp": {
+    "node_modules/randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "requires": {
+      "dependencies": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
-    "readable-stream": {
+    "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "requires": {
+      "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "regenerator-runtime": {
+    "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
-    "regexpp": {
+    "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
     },
-    "request": {
+    "node_modules/request": {
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
         "caseless": "~0.12.0",
@@ -7527,87 +9754,146 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "require-from-string": {
+    "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "requireindex": {
+    "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
+      }
     },
-    "resolve-from": {
+    "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "ret": {
+    "node_modules/ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "engines": {
+        "node": ">=0.12"
+      }
     },
-    "reusify": {
+    "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
     },
-    "rimraf": {
+    "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "requires": {
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dependencies": {
         "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "run-parallel": {
+    "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
-      "requires": {
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
-    "safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
-    "safer-buffer": {
+    "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
-    "semver": {
+    "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "requires": {
+      "dependencies": {
         "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "set-blocking": {
+    "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
-    "setimmediate": {
+    "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
-    "sharp": {
+    "node_modules/sharp": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.2.tgz",
       "integrity": "sha512-WlYOPyyPDiiM07j/UO+E720ju6gtNtHjEGg5vovUk1Lgxyjm2LFO+37Nt/UI3MMh2l6hxTWQWi7qk3cXJTutcQ==",
-      "requires": {
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "libvips": ">=8.15.1",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
         "@img/sharp-darwin-arm64": "0.33.2",
         "@img/sharp-darwin-x64": "0.33.2",
         "@img/sharp-libvips-darwin-arm64": "1.0.1",
@@ -7626,174 +9912,213 @@
         "@img/sharp-linuxmusl-x64": "0.33.2",
         "@img/sharp-wasm32": "0.33.2",
         "@img/sharp-win32-ia32": "0.33.2",
-        "@img/sharp-win32-x64": "0.33.2",
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "semver": "^7.5.4"
+        "@img/sharp-win32-x64": "0.33.2"
       }
     },
-    "shebang-command": {
+    "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "shebang-regex": {
+    "node_modules/shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "signal-exit": {
+    "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
-    "simpl-schema": {
+    "node_modules/simpl-schema": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.13.1.tgz",
       "integrity": "sha512-20Qc2X13TvLJYY37eapvJ5CWyYYSScX2BJV5RcP4A15efA4k8c0XEsp9F/RofQi/IMrp7PzyxTXyjwlG7EFhCQ==",
-      "requires": {
+      "dependencies": {
         "clone": "^2.1.2",
         "message-box": "^0.2.7",
         "mongo-object": "^0.1.4"
       }
     },
-    "simple-swizzle": {
+    "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
-      "requires": {
+      "dependencies": {
         "is-arrayish": "^0.3.1"
       }
     },
-    "simplesvg": {
+    "node_modules/simplesvg": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/simplesvg/-/simplesvg-0.0.10.tgz",
       "integrity": "sha512-iCVx1A/kI4U3cGPRMRQaGLbIFNDXuB8rsaAsO2mM5wYFDs/MrfmHhrSCqNbOylgt9MhhZU3uMsSQnZM853kwXQ==",
-      "requires": {
+      "dependencies": {
         "add-event-listener": "0.0.1"
       }
     },
-    "slash": {
+    "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
-    "slice-ansi": {
+    "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "smart-buffer": {
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
     },
-    "socks": {
+    "node_modules/socks": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
       "integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
       }
     },
-    "sortablejs": {
+    "node_modules/sortablejs": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
       "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
     },
-    "source-map": {
+    "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "source-map-js": {
+    "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "source-map-support": {
+    "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "requires": {
+      "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
     },
-    "sparse-bitfield": {
+    "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
       "dev": true,
       "optional": true,
-      "requires": {
+      "dependencies": {
         "memory-pager": "^1.0.2"
       }
     },
-    "speakingurl": {
+    "node_modules/speakingurl": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
-      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "sprintf-js": {
+    "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "sshpk": {
+    "node_modules/sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
+      "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
         "bcrypt-pbkdf": "^1.0.0",
@@ -7804,285 +10129,377 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "dependencies": {
-        "tweetnacl": {
-          "version": "0.14.5",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-        }
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
       "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
+        "safe-buffer": "~5.2.0"
       }
     },
-    "strip-ansi": {
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
+      "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "strip-json-comments": {
+    "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "strnum": {
+    "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "table": {
+    "node_modules/table": {
       "version": "6.7.5",
       "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
       "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",
         "slice-ansi": "^4.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1"
       },
-      "dependencies": {
-        "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
-    "tar": {
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
       "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
-      "requires": {
+      "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
         "minipass": "^5.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
-    "text-table": {
+    "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "thumbhash": {
+    "node_modules/thumbhash": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/thumbhash/-/thumbhash-0.1.1.tgz",
       "integrity": "sha512-kH5pKeIIBPQXAOni2AiY/Cu/NKdkFREdpH+TLdM0g6WA7RriCv0kPLgP731ady67MhTAqrVG/4mnEeibVuCJcg=="
     },
-    "to-regex-range": {
+    "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
-    "tough-cookie": {
+    "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
+      "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
-    "tr46": {
+    "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "tslib": {
+    "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "tsutils": {
+    "node_modules/tsutils": {
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
       "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "tslib": "^1.8.1"
       },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
-    "tunnel-agent": {
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
+    "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
+      "dependencies": {
         "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "tweetnacl": {
+    "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
-    "type-check": {
+    "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "type-detect": {
+    "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "type-fest": {
+    "node_modules/type-fest": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
-      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw=="
+      "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
-    "typescript": {
+    "node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
-    "undici-types": {
+    "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
-    "uri-js": {
+    "node_modules/uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "requires": {
+      "dependencies": {
         "punycode": "^2.1.0"
       }
     },
-    "util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "v8-compile-cache": {
+    "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
-    "verror": {
+    "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
     },
-    "vivagraphjs": {
+    "node_modules/vivagraphjs": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/vivagraphjs/-/vivagraphjs-0.12.0.tgz",
       "integrity": "sha512-Air+vUHXAWj8NTWUnbU800yKC7SiHpCVwpKIPfDtr5436YoMd7cpg8blt6Fn9xarx+sz1osRxGHBHTaHvcsR6Q==",
-      "requires": {
+      "dependencies": {
         "gintersect": "0.1.0",
         "ngraph.centrality": "0.3.0",
         "ngraph.events": "0.0.3",
@@ -8094,34 +10511,33 @@
         "ngraph.random": "0.0.1",
         "ngraph.tojson": "0.1.4",
         "simplesvg": "0.0.10"
-      },
-      "dependencies": {
-        "ngraph.events": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
-          "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
-        },
-        "ngraph.graph": {
-          "version": "0.0.14",
-          "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-0.0.14.tgz",
-          "integrity": "sha512-ERTLng4KrsGbR7iLZFvg5H+zJ7V+SY8RDqZKYCnOZib5W8M5LCvcil9/8eiJcTRUIPPXW3j8hqPCdLnBvgsn/A==",
-          "requires": {
-            "ngraph.events": "0.0.3"
-          }
-        }
       }
     },
-    "vue": {
+    "node_modules/vivagraphjs/node_modules/ngraph.events": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-0.0.3.tgz",
+      "integrity": "sha512-UrewofHOFk/05otBm9GD4DA3PTEY/yaElhCclmGC4IcmAYaSDRrC3lENQxJ00AzeBnz1GY2xH7Ct7AfIdhsdWA=="
+    },
+    "node_modules/vivagraphjs/node_modules/ngraph.graph": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ngraph.graph/-/ngraph.graph-0.0.14.tgz",
+      "integrity": "sha512-ERTLng4KrsGbR7iLZFvg5H+zJ7V+SY8RDqZKYCnOZib5W8M5LCvcil9/8eiJcTRUIPPXW3j8hqPCdLnBvgsn/A==",
+      "dependencies": {
+        "ngraph.events": "0.0.3"
+      }
+    },
+    "node_modules/vue": {
       "version": "2.6.14",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
+      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details."
     },
-    "vue-eslint-parser": {
+    "node_modules/vue-eslint-parser": {
       "version": "7.11.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.11.0.tgz",
       "integrity": "sha512-qh3VhDLeh773wjgNTl7ss0VejY9bMMa0GoDG2fQVyDzRFdiU3L7fw74tWZDHNQXdZqxO3EveQroa9ct39D2nqg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "debug": "^4.1.1",
         "eslint-scope": "^5.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -8130,121 +10546,182 @@
         "lodash": "^4.17.21",
         "semver": "^6.3.0"
       },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        },
-        "espree": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
-          "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-          "dev": true,
-          "requires": {
-            "acorn": "^7.1.1",
-            "acorn-jsx": "^5.2.0",
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=8.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
-    "vue-meteor-tracker": {
+    "node_modules/vue-eslint-parser/node_modules/eslint-visitor-keys": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/espree": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/vue-eslint-parser/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "8.28.2",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.28.2.tgz",
+      "integrity": "sha512-C5GZjs1tYlAqjwymaaCPDjCyGo10ajUphiwA922jKt9n7KPpqR7oM1PCwYzhB/E7+nT3wfdG3oRre5raIT1rKA==",
+      "deprecated": "Vue I18n v8.x has reached EOL and is no longer actively maintained. About maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
+      "license": "MIT"
+    },
+    "node_modules/vue-meteor-tracker": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vue-meteor-tracker/-/vue-meteor-tracker-2.0.0.tgz",
       "integrity": "sha512-nycG/37787ddogJoEVKOhKWEWJvkfXRXst64A6bX0aVlUA6p5oMpKjwbiSfFMkew/ATyUuarmp4bxIBoCa423Q==",
-      "requires": {
+      "dependencies": {
         "lodash.omit": "^4.5.0"
       }
     },
-    "vue-reactive-provide": {
+    "node_modules/vue-reactive-provide": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/vue-reactive-provide/-/vue-reactive-provide-0.3.0.tgz",
-      "integrity": "sha512-hx2JtRPRvne9NY4s1r7ASsCaO8CIby30qwC1kGQRxsrWApO3he+rziGOzTDSfvmr852zWMb11n6qAwHCz6C/vw=="
+      "integrity": "sha512-hx2JtRPRvne9NY4s1r7ASsCaO8CIby30qwC1kGQRxsrWApO3he+rziGOzTDSfvmr852zWMb11n6qAwHCz6C/vw==",
+      "peerDependencies": {
+        "vue": ">=2.6"
+      }
     },
-    "vue-router": {
+    "node_modules/vue-router": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
       "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
     },
-    "vuedraggable": {
+    "node_modules/vuedraggable": {
       "version": "2.24.3",
       "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
       "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
-      "requires": {
+      "dependencies": {
         "sortablejs": "1.10.2"
       }
     },
-    "vuetify": {
+    "node_modules/vuetify": {
       "version": "2.6.15",
       "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.15.tgz",
-      "integrity": "sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA=="
+      "integrity": "sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA==",
+      "deprecated": "This version is deprecated",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/johnleider"
+      },
+      "peerDependencies": {
+        "vue": "^2.6.4"
+      }
     },
-    "vuetify-upload-button": {
+    "node_modules/vuetify-upload-button": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/vuetify-upload-button/-/vuetify-upload-button-2.0.2.tgz",
       "integrity": "sha512-i4rd+XBFjhesm1GyuwgeSP5moKfBMFOmhkoPRru+DxkVSyD1fAn1W+zko5XyLRAAfIunR3WsFRYWTvZoCwVI9g=="
     },
-    "vuex": {
+    "node_modules/vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
+      }
     },
-    "webidl-conversions": {
+    "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
-    "whatwg-url": {
+    "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "requires": {
+      "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
-    "which": {
+    "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "wide-align": {
+    "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
       "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "requires": {
+      "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "word-wrap": {
+    "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
-    "ws": {
+    "node_modules/ws": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg=="
+      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
-    "yallist": {
+    "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="

--- a/app/package.json
+++ b/app/package.json
@@ -60,6 +60,7 @@
     "type-fest": "^4.32.0",
     "vivagraphjs": "^0.12.0",
     "vue": "2.6.14",
+    "vue-i18n": "^8.28.2",
     "vue-meteor-tracker": "^2.0.0",
     "vue-reactive-provide": "^0.3.0",
     "vue-router": "^3.6.5",


### PR DESCRIPTION
## Context

This PR implements internationalization (i18n) support for DiceCloud, requested in the issue #351, enabling the application to be translated into multiple languages, starting with Brazilian Portuguese (pt-BR). The interface is 90% translated.

## Key Changes

- Set up i18n framework and configuration
- Extracted hardcoded UI strings into translation files
- Added translation files:
  - `locales/en/...` for English (default language)
  - `locales/pt-BR/...` for Brazilian Portuguese
- Implemented language selector on the account settings
- Updated components to use translation functions instead of hardcoded strings
- Configured language fallback mechanism to English.

## Implementation Details

- Translation key pattern: `namespace.section.key`
- Support for interpolation in dynamic texts (names, counters, values)
- Fallback to `en` when translation keys are missing in `pt-BR`
- D&D 5e specific terms kept in English
- Language preference stored in local storage/user settings for persistence


