### PR TITLE
Update invite link to use the new domain

### DIFF
--- a/app/imports/client/ui/user/InviteDialog.vue
+++ b/app/imports/client/ui/user/InviteDialog.vue
@@ -76,7 +76,7 @@ export default {
   computed: {
     inviteLink() {
       let token = this.inviteToken;
-      return token && `https://beta.dicecloud.com/invite/${token}`;
+      return token && `https://dicecloud.com/invite/${token}`;
     },
   },
   methods: {


### PR DESCRIPTION
Removed `beta.` from the invite url and made the url `dicecloud.com/invite`