### PR TITLE
Implement minValue function for dice rolls

### DIFF
--- a/app/imports/parser/functions.ts
+++ b/app/imports/parser/functions.ts
@@ -264,6 +264,33 @@ const parserFunctions: { [name: string]: ParserFunction } = {
       return rollArray;
     },
   },
+  'minValue': {
+      comment: 'Applies a minimum value to all dice in a roll, replacing any result below the minimum with the minimum value. The original low roll is shown with a strikethrough.',
+      examples: [
+          { input: 'minValue(4d6, 3)', result: '[3,5,3,2] with values below 3 shown crossed out and replaced' },
+          { input: 'minValue(1d20, 10)', result: '14' },
+      ],
+      arguments: ['rollArray', 'number'],
+      maxResolveLevels: ['roll', 'reduce'],
+      minArguments: 1,
+      maxArguments: 2,
+      resultType: 'rollArray',
+      fn: function minValueFn(rollArray, minValue = 1) {
+          if (minValue < 1) minValue = 1;
+          if (minValue > rollArray.diceSize) minValue = rollArray.diceSize;
+          const rollValues = rollArray.values;
+          for (let i = rollValues.length - 1; i >= 0; i -= 1) {
+              const roll = rollValues[i];
+              if (roll.disabled) continue;
+              if (roll.value < minValue) {
+                  roll.disabled = true;
+                  roll.disabledBy = 'minValue';
+                  rollValues.splice(i + 1, 0, { value: minValue});
+              }
+          }
+          return rollArray;
+    },
+  },
 }
 
 function anyNumberOf(type) {


### PR DESCRIPTION
Added 'minValue' function to apply minimum value to dice rolls. Decided to remove the reroll section of the input so its now just `minValue(<Dice amount and size>, <Min Value of dice to show>)` its also set up so that the previous result of the dice is still shown but striked through similar to reroll.
<img width="66" height="73" alt="image" src="https://github.com/user-attachments/assets/31582083-38d5-40a3-bfe4-bdab4c5e96d0" />
<img width="105" height="92" alt="image" src="https://github.com/user-attachments/assets/e5e5a3cd-2291-48c6-8bc9-99ce2270c89c" />
<img width="108" height="307" alt="image" src="https://github.com/user-attachments/assets/8df2e74a-0220-417e-93b3-050b17a080a0" />
